### PR TITLE
Add react-dragged class to elements that have been dragged

### DIFF
--- a/lib/draggable.js
+++ b/lib/draggable.js
@@ -274,6 +274,9 @@ module.exports = React.createClass({
 
 	getInitialState: function () {
 		return {
+			// Whether the element has been dragged at any point in time
+			dragged: false,
+
 			// Whether or not currently dragging
 			dragging: false,
 
@@ -302,6 +305,7 @@ module.exports = React.createClass({
 
 		// Initiate dragging
 		this.setState({
+			dragged: true,
 			dragging: true,
 			offsetX: e.clientX,
 			offsetY: e.clientY,
@@ -365,12 +369,12 @@ module.exports = React.createClass({
 	render: function () {
 		var style = {
 			// Set top if vertical drag is enabled
-			top: canDragY(this)
+			top: canDragY(this) && this.state.dragged
 				? this.state.clientY
 				: this.state.startY,
 
 			// Set left if horizontal drag is enabled
-			left: canDragX(this)
+			left: canDragX(this) && this.state.dragged
 				? this.state.clientX
 				: this.state.startX
 		};
@@ -380,11 +384,16 @@ module.exports = React.createClass({
 			style.zIndex = this.props.zIndex;
 		}
 
+		var classes = React.addons.classSet({
+			'react-draggable': true,
+			'react-dragged': this.state.dragged
+		});
+
 		// Reuse the child provided
 		// This makes it flexible to use whatever element is wanted (div, ul, etc)
 		return React.addons.cloneWithProps(React.Children.only(this.props.children), {
 			style: style,
-			className: 'react-draggable',
+			className: classes,
 			onMouseUp: this.handleMouseUp,
 			onMouseDown: this.handleMouseDown
 		});

--- a/lib/styles.css
+++ b/lib/styles.css
@@ -1,8 +1,11 @@
 .react-draggable {
-	position: relative;
 	-webkit-user-select: none;
 	-moz-user-select: none;
 	-ms-user-select: none;
 	-o-user-select: none;
 	user-select: none;
+}
+
+.react-dragged {
+	position: relative;
 }

--- a/specs/draggable.spec.js
+++ b/specs/draggable.spec.js
@@ -81,6 +81,7 @@ describe('react-draggable', function () {
 
 			TestUtils.Simulate.mouseDown(drag.getDOMNode());
 			expect(drag.state.dragging).toEqual(true);
+			expect(drag.state.dragged).toEqual(true);
 		});
 
 		it('should only initialize dragging onmousedown of handle', function () {


### PR DESCRIPTION
This PR allows elements to stay in normal flow until they are actually dragged.
