### PR TITLE
New features: `moveOnStartChange`, event updates, and more

### DIFF
--- a/lib/draggable.js
+++ b/lib/draggable.js
@@ -500,7 +500,7 @@ module.exports = React.createClass({
 		// This makes it flexible to use whatever element is wanted (div, ul, etc)
 		return React.addons.cloneWithProps(React.Children.only(this.props.children), {
 			style: style,
-			className: 'react-draggable',
+			className: 'react-draggable' + (this.state.dragging ? ' react-draggable-dragging' : ''),
 
 			onMouseDown: this.handleDragStart,
 			onTouchStart: function(ev){

--- a/lib/draggable.js
+++ b/lib/draggable.js
@@ -394,6 +394,11 @@ module.exports = React.createClass({
 		// Make it possible to attach event handlers on top of this one
 		this.props.onMouseDown(e);
 
+		// Only catch left clicks, if clicking
+		if (typeof e.button === "number" && e.button !== 0) {
+			return;
+		}
+
 		var node = this.getDOMNode();
 
 		// Short circuit if handle or cancel prop was provided and selector doesn't match

--- a/lib/draggable.js
+++ b/lib/draggable.js
@@ -24,7 +24,7 @@ function canDragX(draggable) {
 }
 
 function isFunction(func) {
-  return typeof func === 'function' || Object.prototype.toString.call(func) === '[object Function]'
+  return typeof func === 'function' || Object.prototype.toString.call(func) === '[object Function]';
 }
 
 // @credits https://gist.github.com/rogozhnikoff/a43cfed27c41e4e68cdc
@@ -55,9 +55,8 @@ if (typeof window === 'undefined') {
     var isTouchDevice = false;
 } else {
     // Do Browser Stuff
-    var isTouchDevice = 'ontouchstart' in window // works on most browsers
-    || 'onmsgesturechange' in window; // works on ie10 on ms surface
-
+    var isTouchDevice = 'ontouchstart' in window || // works on most browsers
+      'onmsgesturechange' in window; // works on ie10 on ms surface
 }
 
 // look ::handleDragStart
@@ -92,7 +91,7 @@ function getControlPosition(e) {
   return {
     clientX: position.clientX,
     clientY: position.clientY
-  }
+  };
 }
 
 function addEvent(el, event, handler) {

--- a/lib/draggable.js
+++ b/lib/draggable.js
@@ -8,8 +8,8 @@ function createUIEvent(draggable) {
 	return {
 		element: draggable.getDOMNode(),
 		position: {
-			top: draggable.state.clientY,
-			left: draggable.state.clientX
+			top: draggable._pendingState.clientY,
+			left: draggable._pendingState.clientX
 		}
 	};
 }

--- a/lib/draggable.js
+++ b/lib/draggable.js
@@ -370,6 +370,10 @@ module.exports = React.createClass({
 			startY: parseInt(node.style.top, 10) || 0
 		});
 
+		// Add a class to the body to disable user-select. This prevents text from 
+		// being selected all over the page.
+		document.body.className += " react-draggable-active";
+
 		// Call event handler
 		this.props.onStart(e, createUIEvent(this));
 
@@ -388,6 +392,9 @@ module.exports = React.createClass({
 		this.setState({
 			dragging: false
 		});
+
+		// Remove the body class used to disable user-select.
+		document.body.className = document.body.className.replace(" react-draggable-active", "");
 
 		// Call event handler
 		this.props.onStop(e, createUIEvent(this));

--- a/lib/draggable.js
+++ b/lib/draggable.js
@@ -215,6 +215,37 @@ module.exports = React.createClass({
 		start: React.PropTypes.object,
 
 		/**
+		 * `moveOnStartChange` tells the Draggable element to reset its position
+		 * if the `start` parameters are changed. By default, if the `start` 
+		 * parameters change, the Draggable element still remains where it started
+		 * or was dragged to.
+		 *
+		 * Example:
+		 *
+		 * ```jsx
+		 * 	var App = React.createClass({
+		 * 			onButtonClick: function () {
+		 * 				this.setState({clicked: true});
+		 * 			},
+		 * 	    render: function () {
+		 * 	    		var start = this.state.clicked ?
+		 * 	    		  {x: 25, y: 25} :
+		 * 	    		  {x: 125, y: 125};
+		 * 	        return (
+		 * 	            <Draggable start={start}>
+		 * 	                <div>I start with left: 25px; top: 25px;,
+		 * 	                but move to left: 125px; top: 125px; when the button
+		 * 	                is clicked.</div>
+		 * 	                <div onClick={this.onButtonClick}>Button</div>
+		 * 	            </Draggable>
+		 * 	        );
+		 * 	    }
+		 * 	});
+		 * ```
+		 */
+		moveOnStartChange: React.PropTypes.bool,
+
+		/**
 		 * `zIndex` specifies the zIndex to use while dragging.
 		 *
 		 * Example:
@@ -294,7 +325,8 @@ module.exports = React.createClass({
 		onStop: React.PropTypes.func,
 
 		/**
-		 * A workaround option which can be passed if onMouseDown needs to be accessed, since it'll always be blocked (due to that there's internal use of onMouseDown)
+		 * A workaround option which can be passed if onMouseDown needs to be accessed, 
+		 * since it'll always be blocked (due to that there's internal use of onMouseDown)
 		 *
 		 */
 		onMouseDown: React.PropTypes.func
@@ -304,6 +336,17 @@ module.exports = React.createClass({
 		// Remove any leftover event handlers
 		removeEvent(window, dragEventFor['move'], this.handleDrag);
 		removeEvent(window, dragEventFor['end'], this.handleDragEnd);
+	},
+
+	componentWillReceiveProps: function(nextProps) {
+		// If this is set to watch a changing start position, 
+		// set x and y to the new position.
+		if (nextProps.moveOnStartChange) {
+			this.setState({
+				clientX: nextProps.start.x,
+				clientY: nextProps.start.y
+			});
+		}
 	},
 
 	getDefaultProps: function () {

--- a/lib/draggable.js
+++ b/lib/draggable.js
@@ -6,6 +6,7 @@ var emptyFunction = require('react/lib/emptyFunction');
 
 function createUIEvent(draggable) {
 	return {
+		element: draggable.getDOMNode(),
 		position: {
 			top: draggable.state.clientY,
 			left: draggable.state.clientX

--- a/lib/draggable.js
+++ b/lib/draggable.js
@@ -468,6 +468,16 @@ module.exports = React.createClass({
 					: this.state.clientY;
 		}
 
+		// Min/max constraints
+		if (Array.isArray(this.props.minConstraints)) {
+			clientX = Math.max(this.props.minConstraints[0], clientX);
+			clientY = Math.max(this.props.minConstraints[1], clientY);
+		}
+		if (Array.isArray(this.props.maxConstraints)) {
+			clientX = Math.min(this.props.maxConstraints[0], clientX);
+			clientY = Math.min(this.props.maxConstraints[1], clientY);
+		}
+
 		// Update top and left
 		this.setState({
 			clientX: clientX,

--- a/lib/styles.css
+++ b/lib/styles.css
@@ -1,8 +1,11 @@
 .react-draggable {
 	position: relative;
-	-webkit-user-select: none;
-	-moz-user-select: none;
-	-ms-user-select: none;
-	-o-user-select: none;
-	user-select: none;
+}
+
+.react-draggable-active {
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  -o-user-select: none;
+  user-select: none;
 }


### PR DESCRIPTION
This is kind of a large PR so please let me know if you'd like it split up.

This is some of the work I did on Draggable to help it play nice with my new [grid project](https://strml.github.io/react-grid-layout/examples/1.html).

The changes are:
- JSHint fixes
- Add `moveOnStartChange`. This flag tells the Draggable to update its `left` and `top` when the `start` param changes. This is used in React-Grid-Layout to move the Draggables when the layout updates.
- Added the DOM Node to the fired event. I use this in RGL for a few reasons and it's not reliably available via `e.target`, and `e.currentTarget` is set incorrectly for some reason. I thought it would be helpful to have.
- Added a class while dragging the element.
- Added a class to the body while dragging to disable user-select. Without it, it's easy to get blue highlights all over your page.

Let me know what you think - if possible it would be great to merge all of the changes rather than split them up.

Thanks
