### PR TITLE
Remove deprecated React @jsx Pragma

### DIFF
--- a/lib/draggable.js
+++ b/lib/draggable.js
@@ -1,6 +1,5 @@
 'use strict';
 
-/** @jsx React.DOM */
 var React = require('react');
 var PureRenderMixin = require('react/lib/ReactComponentWithPureRenderMixin');
 var emptyFunction = require('react/lib/emptyFunction');


### PR DESCRIPTION
Because it was causing errors with including draggable.