### PR TITLE
Remove deprecated React @jsx Pragma

### DIFF
--- a/lib/draggable.js
+++ b/lib/draggable.js
@@ -1,6 +1,5 @@
 'use strict';
 
-/** @jsx React.DOM */
 var React = require('react/addons');
 var emptyFunction = require('react/lib/emptyFunction');
 var CX = React.addons.classSet;


### PR DESCRIPTION
Because it's causing errors including draggable in build process with Babel
