### PR TITLE
Require react not react/addons

### DIFF
--- a/lib/draggable.js
+++ b/lib/draggable.js
@@ -1,7 +1,7 @@
 'use strict';
 
 /** @jsx React.DOM */
-var React = require('react/addons');
+var React = require('react');
 var emptyFunction = require('react/lib/emptyFunction');
 var CX = React.addons.classSet;
 


### PR DESCRIPTION
This fixes the issue with the package not working in webpack, at least for me.  I'd be interested if this resolves it for everyone.  
