### PR TITLE
Require react not react/addons

### DIFF
--- a/lib/draggable.js
+++ b/lib/draggable.js
@@ -1,7 +1,7 @@
 'use strict';
 
 /** @jsx React.DOM */
-var React = require('react/addons');
+var React = require('react');
 var emptyFunction = require('react/lib/emptyFunction');
 var CX = React.addons.classSet;
 


### PR DESCRIPTION
This fixes the issue of the module not working in webpack (at least for me). 
