### PR TITLE
Browserify transforms should be regular dependencies.

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,9 +36,11 @@
     "karma-jasmine": "^0.1.5",
     "karma-webpack": "^1.2.1",
     "react": "^0.12.0",
-    "reactify": "^0.17.1",
     "uglify-js": "^2.4.15",
     "webpack": "^1.3.2-beta8",
     "webpack-dev-server": "^1.4.7"
+  },
+  "dependencies": {
+    "reactify": "^0.17.1"
   }
 }


### PR DESCRIPTION
This prevents CoffeeScript-based projects that don't already include reactify
from throwing exceptions while running Browserify.
