### PR TITLE
Move brief API documentation out of example

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,41 @@ positioning (relative, absolute, or static). Elements can also be moved between 
 If the item you are dragging already has a CSS Transform applied, it will be overwritten by `<Draggable>`. Use
 an intermediate wrapper (`<Draggable><span>...</span></Draggable>`) in this case.
 
-## Example
+## API
+The `<Draggable/>` component transparently adds draggable to whatever element is supplied as `this.props.children`.
+**Note**: Only a single element is allowed or an Error will be thrown.
+
+Props:
+
+**`axis`**: determines which axis the draggable can move. Accepted values:
+- `both` allows movement horizontally and vertically (default).
+- `x` limits movement to horizontal axis.
+- `y` limits movement to vertical axis.
+
+**`handle`**: specifies a selector to be used as the handle that initiates drag.
+
+**`cancel`**: specifies a selector to be used to prevent drag initialization.
+
+**`grid`**: specifies the x and y that dragging should snap to.
+ 
+**`bounds`**: specifies movement boundaries. Accepted values:
+- `parent` restricts movement within the node's offsetParent (nearest node with position relative or absolute), or
+- An object with `left, top, right, and bottom` properties. These indicate how far in each direction the draggable can be moved. See [example/index.html](https://github.com/mzabriskie/react-draggable/blob/master/example/index.html) for more on this.
+
+**`start`**: specifies the `x` and `y` that the dragged item should start at. This is generally not necessary to use (you can use absolute or relative positioning of the child directly), but can be helpful for uniformity in your callbacks and with css transforms.
+
+**`moveOnStartChange`**: if true (it defaults false), will move the element if there is a change in `start`. We set this by default to `false` because it can cause unwanted effects if you are not aware of it.
+
+**`zIndex`**: specifies the zIndex to use while dragging.
+
+**`onStart`**: called when dragging starts.
+
+**`onDrag`**: called while dragging.
+
+**`onStop`**: called when dragging stops.
+
+
+## Example usage
 
 ```js
 /** @jsx React.DOM */
@@ -57,44 +91,6 @@ var App = React.createClass({
 
 	render: function () {
 		return (
-			// <Draggable/> transparently adds draggable interactivity
-			// to whatever element is supplied as `this.props.children`.
-			// Only a single element is allowed or an Error will be thrown.
-			//
-			// The element is moved from its current position using absolute positioning.
-			//
-			// `axis` determines which axis the draggable can move.
-			// - 'both' allows movement horizontally and vertically (default).
-			// - 'x' limits movement to horizontal axis.
-			// - 'y' limits movement to vertical axis.
-			//
-			// `handle` specifies a selector to be used as the handle that initiates drag.
-			//
-			// `cancel` specifies a selector to be used to prevent drag initialization.
-			//
-			// `grid` specifies the x and y that dragging should snap to.
-			//
-			// `bounds` specifies movement boundaries. Pass:
-			// - 'parent' restricts movement within the node's offsetParent
-			//	 (nearest node with position relative or absolute), or
-			// - An object with left, top, right, and bottom properties. These indicate how far in each direction
-			//   the draggable can be moved. See example/index.html for more on this.
-			//
-			// `start` specifies the x and y that the dragged item should start at. This is generally not necessary
-			//   to use (you can use absolute or relative positioning of the child directly), but can be helpful
-			//   for uniformity in your callbacks and with css transforms.
-			//
-			// `moveOnStartChange`, if true (default false), will move the element if there is a change in `start`.
-			//   We set this by default to `false` because it can cause unwanted effects if you are not aware of it.
-			//
-			// `zIndex` specifies the zIndex to use while dragging.
-			//
-			// `onStart` is called when dragging starts.
-			//
-			// `onDrag` is called while dragging.
-			//
-			// `onStop` is called when dragging stops.
-
 			<Draggable
 				axis="x"
 				handle=".handle"
@@ -107,7 +103,7 @@ var App = React.createClass({
 				onStop={this.handleStop}>
 				<div>
 					<div className="handle">Drag from here</div>
-					<div>Lorem ipsum...</div>
+					<div>This readme is really dragging on...</div>
 				</div>
 			</Draggable>
 		);
@@ -116,6 +112,8 @@ var App = React.createClass({
 
 React.renderComponent(<App/>, document.body);
 ```
+
+
 
 ## Contributing
 


### PR DESCRIPTION
Really love this component and thought it might be helpful for other people if the props for a `<Draggable/>` were more clearly documented. I don't usually look in code examples for documentation about a given API and it might help people clearly see how to clearly use the module while still including an easy-to-get usage example. Open to thoughts / feedback / &c.!
