### PR TITLE
Only react to changes in start param if it has actually changed

### DIFF
--- a/lib/draggable.js
+++ b/lib/draggable.js
@@ -467,8 +467,10 @@ module.exports = React.createClass({
   },
 
   componentWillReceiveProps: function(newProps) {
-    // React to changes in the 'start' param.
-    if (newProps.moveOnStartChange && newProps.start) {
+    // React to changes in the 'start' param, but only if it has changed.
+    if (newProps.moveOnStartChange && newProps.start &&
+      this.props.start && this.props.start.x !== newProps.start.x &&
+      this.props.start.y !== newProps.start.y) {
       this.setState(this.getInitialState(newProps));
     }
   },


### PR DESCRIPTION
Hi,
Loving react-draggable, thanks!
I came across an issue where a component needed to re-render, sending an unchanged "start" prop to a Draggable while a drag was happening. Adding logic to not reset the state when "start" was unchanged fixed this. I think this behaviour is sensible as a default, hence this pull request.

Thanks again!
