### PR TITLE
Adding the option for percentag based dragging

### DIFF
--- a/lib/draggable.js
+++ b/lib/draggable.js
@@ -15,6 +15,10 @@ function createUIEvent(draggable) {
   var state = draggable._pendingState || draggable.state;
   return {
     node: draggable.getDOMNode(),
+    percentage: {
+      top: state.percentY,
+      left: state.percentX
+    },
     position: {
       top: state.clientY,
       left: state.clientX
@@ -463,7 +467,9 @@ module.exports = React.createClass({
      * A workaround option which can be passed if onMouseDown needs to be accessed,
      * since it'll always be blocked (due to that there's internal use of onMouseDown)
      */
-    onMouseDown: React.PropTypes.func
+    onMouseDown: React.PropTypes.func,
+
+    percentage: React.PropTypes.bool
   },
 
   componentWillReceiveProps: function(newProps) {
@@ -544,7 +550,6 @@ module.exports = React.createClass({
       scrollY: document.body.scrollTop
     });
 
-
     // Add event handlers
     addEvent(document, 'scroll', this.handleScroll);
     addEvent(document, dragEventFor.move, this.handleDrag);
@@ -593,15 +598,17 @@ module.exports = React.createClass({
       clientY = pos[1];
     }
 
-    // Call event handler. If it returns explicit false, cancel.
-    var shouldUpdate = this.props.onDrag(e, createUIEvent(this));
-    if (shouldUpdate === false) return this.handleDragEnd();
+    var rect = this.getDOMNode().parentNode.getBoundingClientRect();
 
     // Update transform
     this.setState({
+      percentX: (dragPoint.clientX - rect.left) / rect.width * 100,
+      percentY: (dragPoint.clientY - rect.top) / rect.height * 100,
       clientX: clientX,
       clientY: clientY
     });
+
+    this.props.onDrag(e, createUIEvent(this));
   },
 
   handleScroll: function(e) {
@@ -653,17 +660,29 @@ module.exports = React.createClass({
     // without worrying about whether or not it is relatively or absolutely positioned.
     // If the item you are dragging already has a transform set, wrap it in a <span> so <Draggable>
     // has a clean slate.
-    var transform = createCSSTransform({
-      // Set left if horizontal drag is enabled
-      x: canDragX(this) ?
-        this.state.clientX :
-        0,
+    var offsetStyle = {};
+    var bounds, rect;
 
-      // Set top if vertical drag is enabled
-      y: canDragY(this) ?
-        this.state.clientY :
-        0
-    });
+    if (this.props.percentage) {
+      if (canDragX(this) && 'percentX' in this.state) {
+        offsetStyle.left = this.state.percentX + '%';
+      }
+      if (canDragY(this) && 'percentY' in this.state) {
+        offsetStyle.top = this.state.percentY + '%';
+      }
+    } else {
+      offsetStyle = createCSSTransform({
+        // Set left if horizontal drag is enabled
+        x: canDragX(this) ?
+          this.state.clientX :
+          0,
+
+        // Set top if vertical drag is enabled
+        y: canDragY(this) ?
+          this.state.clientY :
+          0
+      });
+    }
 
     // Workaround IE pointer events; see #51
     // https://github.com/mzabriskie/react-draggable/issues/51#issuecomment-103488278
@@ -671,7 +690,7 @@ module.exports = React.createClass({
       touchAction: 'none'
     };
 
-    var style = assign({}, childStyle, transform, touchHacks);
+    var style = assign({}, childStyle, offsetStyle, touchHacks);
 
     // Set zIndex if currently dragging and prop has been provided
     if (this.state.dragging && !isNaN(this.props.zIndex)) {


### PR DESCRIPTION
This is an initial attempt at adding percentage based offsets to address #63.

One of the odd things in this plugin is the ability to cancel the drag events by returning false from onDrag. I don't think this is healthy for the API. This change initially ignore the return value in the the drag callback for code convenience.

If this works for you I can clean up the code a bit, make sure it matches style, and update the documentation.
