### PR TITLE
Add multitouch support

### DIFF
--- a/lib/draggable.js
+++ b/lib/draggable.js
@@ -516,7 +516,7 @@ module.exports = React.createClass({
   handleDragStart: function (e) {
     // Set touch identifier in component state if this is a touch event
     if(e.targetTouches){
-      this.setState({identifier: e.targetTouches[0].identifier});
+      this.setState({touchIdentifier: e.targetTouches[0].identifier});
     }
     
     // Make it possible to attach event handlers on top of this one
@@ -562,6 +562,11 @@ module.exports = React.createClass({
       return;
     }
 
+    // Short circuit if this is not the correct touch event
+    if(e.changedTouches && (e.changedTouches[0].identifier != this.state.touchIdentifier)){
+     return;
+    } 
+
     removeUserSelectStyles(this);
 
     // Turn off dragging
@@ -580,7 +585,7 @@ module.exports = React.createClass({
 
   handleDrag: function (e) {
     // Return if this is a touch event, but not the correct one for this element
-    if(e.targetTouches && (e.targetTouches[0].identifier != this.state.identifier)){
+    if(e.targetTouches && (e.targetTouches[0].identifier != this.state.touchIdentifier)){
       return;
     }
     var dragPoint = getControlPosition(e);

--- a/lib/draggable.js
+++ b/lib/draggable.js
@@ -579,7 +579,7 @@ module.exports = React.createClass({
   },
 
   handleDrag: function (e) {
-    // Return if this is a touch event, but not the correct one for thiss element
+    // Return if this is a touch event, but not the correct one for this element
     if(e.targetTouches && (e.targetTouches[0].identifier != this.state.identifier)){
       return;
     }

--- a/lib/draggable.js
+++ b/lib/draggable.js
@@ -81,7 +81,7 @@ var dragEventFor = eventsFor.mouse;
  * get {clientX, clientY} positions of control
  * */
 function getControlPosition(e) {
-  var position = (e.touches && e.touches[0]) || e;
+  var position = (e.targetTouches && e.targetTouches[0]) || e;
   return {
     clientX: position.clientX,
     clientY: position.clientY
@@ -514,6 +514,11 @@ module.exports = React.createClass({
   },
 
   handleDragStart: function (e) {
+    // Set touch identifier in component state if this is a touch event
+    if(e.targetTouches){
+      this.setState({identifier: e.targetTouches[0].identifier});
+    }
+    
     // Make it possible to attach event handlers on top of this one
     this.props.onMouseDown(e);
 
@@ -574,6 +579,10 @@ module.exports = React.createClass({
   },
 
   handleDrag: function (e) {
+    // Return if this is a touch event, but not the correct one for thiss element
+    if(e.targetTouches && (e.targetTouches[0].identifier != this.state.identifier)){
+      return;
+    }
     var dragPoint = getControlPosition(e);
 
     // Calculate X and Y


### PR DESCRIPTION
Hi, these changes should enable multi-touch support, so that elements can be individually dragged at the same time, when using a multi-touch device.

I've tested this successfully on Chrome for Android. On Firefox for Android, scroll and zoom aren't being prevented (a separate issue?) I unfortunately do not have an iOS device to test with.

This adds a few conditional statements in the event handlers, but it didn't seem to impact performance when testing on my laptop. The original tests all pass, and everything in the demo is functioning as I would expect it to (The "Active Drags" counter is fun to watch, now)

I would like to add unit tests for this, but I'm not sure how to simulate this situation - everything depends on how the state of each component changes.

There might be a more performance-savvy way to do this by having one set of touch event listeners per app, but that would take a significant refactoring and might not be in line with the philosophy of React.

Please let me know what you think!
