### PR TITLE
fix x/y position when axis limit is enabled

### DIFF
--- a/lib/draggable.js
+++ b/lib/draggable.js
@@ -671,12 +671,12 @@ module.exports = React.createClass({
       // Set left if horizontal drag is enabled
       x: canDragX(this) ?
         this.state.clientX :
-        0,
+        this.props.start.x,
 
       // Set top if vertical drag is enabled
       y: canDragY(this) ?
         this.state.clientY :
-        0
+        this.props.start.y
     });
 
     // Workaround IE pointer events; see #51


### PR DESCRIPTION
when axis="x" (or axis="y") is enabled, the start y (or x) position becomes 0, correct value should be this.props.start.x (or this.props.start.y)
