### PR TITLE
Updating README to reflect child element's required API

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,14 @@ an intermediate wrapper (`<Draggable><span>...</span></Draggable>`) in this case
 The `<Draggable/>` component transparently adds draggable to whatever element is supplied as `this.props.children`.
 **Note**: Only a single element is allowed or an Error will be thrown.
 
+In addition, the child element must provide support for the following props:
+- `style` is used to give the transform css to the child.
+- `className` is used to apply the proper classes to the object being dragged.
+- `onMouseDown` is used along with onMouseUp to keep track of dragging state.
+- `onMouseUp` is used along with onMouseDown to keep track of dragging state.
+- `onTouchStart` is used along with onTouchEnd to keep track of dragging state.
+- `onTouchEnd` is used along with onTouchStart to keep track of dragging state.
+
 Props:
 
 **`axis`**: determines which axis the draggable can move. Accepted values:

--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ In addition, the child element must provide support for the following props:
 - `onTouchStart` is used along with onTouchEnd to keep track of dragging state.
 - `onTouchEnd` is used along with onTouchStart to keep track of dragging state.
 
+React.DOM elements support the above six properties by default, so you may use those elements as children without any changes. If you wish to use a React component you created, you might find [this React page](https://facebook.github.io/react/docs/transferring-props.html) helpful.
+
 Props:
 
 **`axis`**: determines which axis the draggable can move. Accepted values:

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ an intermediate wrapper (`<Draggable><span>...</span></Draggable>`) in this case
 The `<Draggable/>` component transparently adds draggable to whatever element is supplied as `this.props.children`.
 **Note**: Only a single element is allowed or an Error will be thrown.
 
-In addition, the child element must provide support for the following props:
+For the `<Draggable/>` component to correctly attach itself to its child, the child element must provide support for the following props:
 - `style` is used to give the transform css to the child.
 - `className` is used to apply the proper classes to the object being dragged.
 - `onMouseDown` is used along with onMouseUp to keep track of dragging state.


### PR DESCRIPTION
Draggable currently requires the style, className, onMouseDown, onMouseUp, onTouchStart, and onTouchEnd props to be handled by the child element. This change makes the requirement explicit in the README so that users will hopefully not be confused in the future.
