### PR TITLE
pre might be null or undefined 

### DIFF
--- a/lib/getPrefix.js
+++ b/lib/getPrefix.js
@@ -8,6 +8,7 @@ module.exports = function() {
         .match(/-(moz|webkit|ms)-/) || (styles.OLink === '' && ['', 'o'])
       )[1];
   // 'ms' is not titlecased
+  if(pre === undefined || pre === null) return '';
   if (pre === 'ms') return pre;
   return pre.slice(0, 1).toUpperCase() + pre.slice(1);
 };


### PR DESCRIPTION
This PR fixes the fringe case where pre is `undefined` or `null`, in one of those cases calling `.slice()` will throw an error. This happened when using this library in tests that make use of jsdom.
