### PR TITLE
Add install static-server to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,7 @@ If you want an `<img>` to be draggable, set `<img draggable="false" />`. See the
 ## Contributing
 
 - Fork the project
+- Install static-server: `$ npm install -g static-server`
 - Run the project in development mode: `$ make dev`
 - Make changes.
 - Add appropriate tests


### PR DESCRIPTION
`static-server` command is a requirement of build-watch so it makes sense to mention it in readme.
