### PR TITLE
Fix server-side rendering

### DIFF
--- a/lib/utils/getPrefix.es6
+++ b/lib/utils/getPrefix.es6
@@ -1,5 +1,9 @@
 export default (function() {
-  if (typeof window === 'undefined') return '';
+  // Checking specifically for 'window.document' is for pseudo-browser server-side
+  // environments that define 'window' as the global context.
+  // E.g. React-rails (see https://github.com/reactjs/react-rails/pull/84)
+  if (typeof window === 'undefined' || typeof window.document === 'undefined') return '';
+
   // Thanks David Walsh
   let styles = window.getComputedStyle(document.documentElement, ''),
   pre = (Array.prototype.slice


### PR DESCRIPTION
Handle pseudo-browser environments when rendering server-side where `window` may be defined as the global context like in [react-rails](https://github.com/reactjs/react-rails/blob/024cdbf64c03038503788a783b393e13cdaa22c7/lib/react/server_rendering/exec_js_renderer.rb#L34-L36)
