### PR TITLE
Skip handleDrag if disabled

### DIFF
--- a/lib/DraggableCore.es6
+++ b/lib/DraggableCore.es6
@@ -304,6 +304,9 @@ export default class DraggableCore extends React.Component {
     // Return if this is a touch event, but not the correct one for this element
     if (e.targetTouches && (e.targetTouches[0].identifier !== this.state.touchIdentifier)) return;
 
+    // Return if disabled
+    if (this.props.disabled) return;
+
     let {clientX, clientY} = getControlPosition(e);
 
     // Snap to grid if prop has been provided


### PR DESCRIPTION
Skip the `handleDrag` When disabled, because, If it becomes disabled at the drag start event, it would be dragged.
