### PR TITLE
Use explicit constructor in Draggable to fix IE10 null reference

### DIFF
--- a/lib/Draggable.es6
+++ b/lib/Draggable.es6
@@ -18,6 +18,11 @@ type DraggableState = {
   isElementSVG: boolean
 };
 
+type ConstructorProps = {
+  position: { x: number, y: number },
+  defaultPosition: { x: number, y: number }
+}
+
 //
 // Define <Draggable>
 //
@@ -145,22 +150,28 @@ export default class Draggable extends React.Component {
     position: null
   };
 
-  state: DraggableState = {
-    // Whether or not we are currently dragging.
-    dragging: false,
+  state: DraggableState;
 
-    // Whether or not we have been dragged before.
-    dragged: false,
+  constructor(props: ConstructorProps) {
+    super(props);
 
-    // Current transform x and y.
-    x: this.props.position ? this.props.position.x : this.props.defaultPosition.x,
-    y: this.props.position ? this.props.position.y : this.props.defaultPosition.y,
+    this.state = {
+      // Whether or not we are currently dragging.
+      dragging: false,
 
-    // Used for compensating for out-of-bounds drags
-    slackX: 0, slackY: 0,
+      // Whether or not we have been dragged before.
+      dragged: false,
 
-    // Can only determine if SVG after mounting
-    isElementSVG: false
+      // Current transform x and y.
+      x: props.position ? props.position.x : props.defaultPosition.x,
+      y: props.position ? props.position.y : props.defaultPosition.y,
+
+      // Used for compensating for out-of-bounds drags
+      slackX: 0, slackY: 0,
+
+      // Can only determine if SVG after mounting
+      isElementSVG: false
+    };
   };
 
   componentWillMount() {
@@ -327,4 +338,3 @@ export default class Draggable extends React.Component {
     );
   }
 }
-


### PR DESCRIPTION
There's a problem in IE10 with ES2015 classes and the super class.
Essentially the prototype isn't set up correctly which leads to
this.props being null when setting up position in the construction.

However, props are passed to the class constructor explicitly by React,
so we can use them from there.

Tested by running the examples in IE 10 on Win 7.

This is basically the same problem as addressed in #145, but fixed to work rather than just not blow up (and for version 2 props).
