### PR TITLE
Fix for 'cannot access clientX on undefined' exception.

### DIFF
--- a/lib/utils/domFns.es6
+++ b/lib/utils/domFns.es6
@@ -84,7 +84,7 @@ export function innerWidth(node: HTMLElement): number {
 
 // Get from offsetParent
 export function offsetXYFromParentOf(e: MouseEvent, node: HTMLElement & {offsetParent: HTMLElement}): ControlPosition {
-  const evt = e.targetTouches ? e.targetTouches[0] : e;
+  const evt = e.targetTouches && e.targetTouches.length ? e.targetTouches[0] : e;
 
   const offsetParent = node.offsetParent || document.body;
   const offsetParentRect = node.offsetParent === document.body ? {left: 0, top: 0} : offsetParent.getBoundingClientRect();


### PR DESCRIPTION
To reproduce, access a DraggableCore element using touch emulation in Chrome.   The exception will be thrown on drag stop.

This will leave the element active, so if you drag another element, both elements end up being dragged together.

I'm not sure if this is the correct fix, I may be treating symptoms rather than root cause, but it appears to work.
