### PR TITLE
Fix propType tests for latest React (v15.2.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,7 +253,7 @@ on itself and thus must have callbacks attached to be useful.
   handle: string,
   onStart: DraggableEventHandler,
   onDrag: DraggableEventHandler,
-  onStop: DraggableEventHandler
+  onStop: DraggableEventHandler,
   onMouseDown: (e: MouseEvent) => void
 }
 ```

--- a/specs/draggable.spec.jsx
+++ b/specs/draggable.spec.jsx
@@ -122,7 +122,11 @@ describe('react-draggable', function () {
 
       TestUtils.renderIntoDocument(drag);
 
-      expect(console.error).toHaveBeenCalledWith('Warning: Failed propType: Invalid prop className passed to Draggable - do not set this, set it on the child.');
+      expect(
+        console.error.calls.argsFor(0)[0].replace('propType:', 'prop type:').split('\n')[0]
+      ).toBe(
+        'Warning: Failed prop type: Invalid prop className passed to Draggable - do not set this, set it on the child.'
+      );
     });
 
     it('should throw when setting style', function () {
@@ -130,7 +134,11 @@ describe('react-draggable', function () {
 
       TestUtils.renderIntoDocument(drag);
 
-      expect(console.error).toHaveBeenCalledWith('Warning: Failed propType: Invalid prop style passed to Draggable - do not set this, set it on the child.');
+      expect(
+        console.error.calls.argsFor(0)[0].replace('propType:', 'prop type:').split('\n')[0]
+      ).toBe(
+        'Warning: Failed prop type: Invalid prop style passed to Draggable - do not set this, set it on the child.'
+      );
     });
 
     it('should throw when setting transform', function () {
@@ -138,7 +146,11 @@ describe('react-draggable', function () {
 
       TestUtils.renderIntoDocument(drag);
 
-      expect(console.error).toHaveBeenCalledWith('Warning: Failed propType: Invalid prop transform passed to Draggable - do not set this, set it on the child.');
+      expect(
+        console.error.calls.argsFor(0)[0].replace('propType:', 'prop type:').split('\n')[0]
+      ).toBe(
+        'Warning: Failed prop type: Invalid prop transform passed to Draggable - do not set this, set it on the child.'
+      );
     });
 
     it('should call onStart when dragging begins', function () {


### PR DESCRIPTION
React 15.2.0 changed the propType validation warning text:
https://github.com/facebook/react/blob/master/CHANGELOG.md#1520-july-1-2
016

This PR adapts the assertion to work for both versions of the warning text.
