### PR TITLE
Use window/document relative to DOM element

### DIFF
--- a/lib/utils/domFns.es6
+++ b/lib/utils/domFns.es6
@@ -63,7 +63,7 @@ export function outerHeight(node: HTMLElement): number {
   // This is deliberately excluding margin for our calculations, since we are using
   // offsetTop which is including margin. See getBoundPosition
   let height = node.clientHeight;
-  const computedStyle = window.getComputedStyle(node);
+  const computedStyle = node.ownerDocument.defaultView.getComputedStyle(node);
   height += int(computedStyle.borderTopWidth);
   height += int(computedStyle.borderBottomWidth);
   return height;
@@ -73,14 +73,14 @@ export function outerWidth(node: HTMLElement): number {
   // This is deliberately excluding margin for our calculations, since we are using
   // offsetLeft which is including margin. See getBoundPosition
   let width = node.clientWidth;
-  const computedStyle = window.getComputedStyle(node);
+  const computedStyle = node.ownerDocument.defaultView.getComputedStyle(node);
   width += int(computedStyle.borderLeftWidth);
   width += int(computedStyle.borderRightWidth);
   return width;
 }
 export function innerHeight(node: HTMLElement): number {
   let height = node.clientHeight;
-  const computedStyle = window.getComputedStyle(node);
+  const computedStyle = node.ownerDocument.defaultView.getComputedStyle(node);
   height -= int(computedStyle.paddingTop);
   height -= int(computedStyle.paddingBottom);
   return height;
@@ -88,15 +88,14 @@ export function innerHeight(node: HTMLElement): number {
 
 export function innerWidth(node: HTMLElement): number {
   let width = node.clientWidth;
-  const computedStyle = window.getComputedStyle(node);
+  const computedStyle = node.ownerDocument.defaultView.getComputedStyle(node);
   width -= int(computedStyle.paddingLeft);
   width -= int(computedStyle.paddingRight);
   return width;
 }
 
 // Get from offsetParent
-export function offsetXYFromParent(evt: {clientX: number, clientY: number}, offsetParent: ?HTMLElement): ControlPosition {
-  if (!offsetParent) offsetParent = document.body;
+export function offsetXYFromParent(evt: {clientX: number, clientY: number}, offsetParent: HTMLElement): ControlPosition {
   const isBody = offsetParent === offsetParent.ownerDocument.body;
   const offsetParentRect = isBody ? {left: 0, top: 0} : offsetParent.getBoundingClientRect();
 
@@ -132,14 +131,15 @@ const userSelectPrefix = getPrefix('user-select');
 const userSelect = browserPrefixToStyle('user-select', userSelectPrefix);
 const userSelectStyle = `;${userSelect}: none;`;
 
-export function addUserSelectStyles() {
-  const style = document.body.getAttribute('style') || '';
-  document.body.setAttribute('style', style + userSelectStyle);
+// Note we're passing `document` b/c we could be iframed
+export function addUserSelectStyles(body: HTMLElement) {
+  const style = body.getAttribute('style') || '';
+  body.setAttribute('style', style + userSelectStyle);
 }
 
-export function removeUserSelectStyles() {
-  const style = document.body.getAttribute('style') || '';
-  document.body.setAttribute('style', style.replace(userSelectStyle, ''));
+export function removeUserSelectStyles(body: HTMLElement) {
+  const style = body.getAttribute('style') || '';
+  body.setAttribute('style', style.replace(userSelectStyle, ''));
 }
 
 export function styleHacks(childStyle: Object = {}): Object {

--- a/lib/utils/positionFns.es6
+++ b/lib/utils/positionFns.es6
@@ -17,15 +17,17 @@ export function getBoundPosition(draggable: Draggable, x: number, y: number): [n
   const node = ReactDOM.findDOMNode(draggable);
 
   if (typeof bounds === 'string') {
+    const {currentDocument} = node;
+    const currentWindow = node.defaultView;
     let boundNode;
     if (bounds === 'parent') {
       boundNode = node.parentNode;
     } else {
-      boundNode = document.querySelector(bounds);
+      boundNode = currentDocument.querySelector(bounds);
       if (!boundNode) throw new Error('Bounds selector "' + bounds + '" could not find an element.');
     }
-    const nodeStyle = window.getComputedStyle(node);
-    const boundNodeStyle = window.getComputedStyle(boundNode);
+    const nodeStyle = currentWindow.getComputedStyle(node);
+    const boundNodeStyle = currentWindow.getComputedStyle(boundNode);
     // Compute bounds. This is a pain with padding and offsets but this gets it exactly right.
     bounds = {
       left: -node.offsetLeft + int(boundNodeStyle.paddingLeft) +
@@ -66,10 +68,9 @@ export function canDragY(draggable: Draggable): boolean {
 export function getControlPosition(e: MouseEvent, touchIdentifier: ?number, draggableCore: DraggableCore): ?ControlPosition {
   const touchObj = typeof touchIdentifier === 'number' ? getTouch(e, touchIdentifier) : null;
   if (typeof touchIdentifier === 'number' && !touchObj) return null; // not the right touch
+  const node = ReactDOM.findDOMNode(draggableCore);
   // User can provide an offsetParent if desired.
-  const offsetParent = draggableCore.props.offsetParent ||
-                       ReactDOM.findDOMNode(draggableCore).offsetParent ||
-                       document.body;
+  const offsetParent = draggableCore.props.offsetParent || node.offsetParent || node.ownerDocument.body;
   return offsetXYFromParent(touchObj || e, offsetParent);
 }
 


### PR DESCRIPTION
Use the ownerDocument and window of the DOM element being manipulated
rather than the global window and document objects. This makes
react-draggable work with a tool like
https://github.com/ryanseddon/react-frame-component

This replaces #177 which still needs some tests.
