### PR TITLE
Add tests for the Draggable component when rendered into an iframe

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "pre-commit": "^1.1.3",
     "react": "^15.2.1",
     "react-dom": "^15.2.1",
+    "react-frame-component": "0.6.2",
     "semver": "^5.3.0",
     "static-server": "^2.0.3",
     "uglify-js": "^2.7.0",


### PR DESCRIPTION
Add tests for #180 (all passing ✅ )

Note that I was unable to get these tests working using TestUtils’ `renderIntoDocument` function (or the various `find*` helpers) and had to use actual `ReactDOM.render` along with `querySelector` on the returned DOM node to make assertions on the rendered results. Has something to do with the tricky parts of react-frame-component (rendering an iframe with React), and looking at the [react-frame-component tests](https://github.com/ryanseddon/react-frame-component/blob/master/test/Frame_spec.js#L62), they take the same approach.

As a result of needing to use ReactDOM.render, I had to add a setTimeout before selecting the rendered nodes from the DOM to avoid the tests breaking in Firefox. Here’s the error I saw when I tried to select the nodes synchronously:

```
[1A[2K[1A[2K[1A[2KFirefox 42.0.0 (Mac OS X 10.11.0) react-draggable props should be draggable when in an iframe FAILED
    TypeError: domComponentOrNode is null in specs/main.js (line 22648)
    makeSimulator/<@specs/main.js:22648:1
    simulateMovementFromTo@specs/main.js:1376:1
    @specs/main.js:801:8
```

I had another weird seemingly unrelated test failure on Firefox that I [worked around](https://github.com/mzabriskie/react-draggable/pull/182/files#diff-1ab96138dbff84fa03196519e7e04dcdR535) by rounding the mouse event’s `deltaY` in the onDrag function’s assertions. Here’s that error:

```
Firefox 42.0.0 (Mac OS X 10.11.0): Executed 11 of 37 (2 FAILED) (0 secs / 0.096 secs)
[1A[2K[1A[2K[1A[2KFirefox 42.0.0 (Mac OS X 10.11.0) ERROR
  AssertionError:   # specs/draggable.spec.jsx:527

    assert(coreEvent.deltaY === 500)
           |         |      |       
           |         |      false   
           |         500.00001525878906
           Object{node:#HTMLDivElement#,x:0,y:500.00001525878906,deltaX:0,deltaY:500.00001525878906,lastX:0,lastY:0}

    [number] 500
    => 500
    [number] coreEvent.deltaY
    => 500.00001525878906
```
