### PR TITLE
Avoid having 'global' 'undefined'

### DIFF
--- a/dist/react-draggable.js
+++ b/dist/react-draggable.js
@@ -11,41 +11,41 @@
 return /******/ (function(modules) { // webpackBootstrap
 /******/ 	// The module cache
 /******/ 	var installedModules = {};
-/******/
+
 /******/ 	// The require function
 /******/ 	function __webpack_require__(moduleId) {
-/******/
+
 /******/ 		// Check if module is in cache
 /******/ 		if(installedModules[moduleId])
 /******/ 			return installedModules[moduleId].exports;
-/******/
+
 /******/ 		// Create a new module (and put it into the cache)
 /******/ 		var module = installedModules[moduleId] = {
 /******/ 			exports: {},
 /******/ 			id: moduleId,
 /******/ 			loaded: false
 /******/ 		};
-/******/
+
 /******/ 		// Execute the module function
 /******/ 		modules[moduleId].call(module.exports, module, module.exports, __webpack_require__);
-/******/
+
 /******/ 		// Flag the module as loaded
 /******/ 		module.loaded = true;
-/******/
+
 /******/ 		// Return the exports of the module
 /******/ 		return module.exports;
 /******/ 	}
-/******/
-/******/
+
+
 /******/ 	// expose the modules object (__webpack_modules__)
 /******/ 	__webpack_require__.m = modules;
-/******/
+
 /******/ 	// expose the module cache
 /******/ 	__webpack_require__.c = installedModules;
-/******/
+
 /******/ 	// __webpack_public_path__
 /******/ 	__webpack_require__.p = "";
-/******/
+
 /******/ 	// Load entry module and return exports
 /******/ 	return __webpack_require__(0);
 /******/ })
@@ -55,7 +55,7 @@ return /******/ (function(modules) { // webpackBootstrap
 /***/ function(module, exports, __webpack_require__) {
 
 	'use strict';
-	
+
 	module.exports = __webpack_require__(1).default;
 	module.exports.DraggableCore = __webpack_require__(9).default;
 
@@ -63,56 +63,60 @@ return /******/ (function(modules) { // webpackBootstrap
 /* 1 */
 /***/ function(module, exports, __webpack_require__) {
 
-	/* WEBPACK VAR INJECTION */(function(global) {'use strict';
-	
+	'use strict';
+
 	Object.defineProperty(exports, "__esModule", {
 	  value: true
 	});
-	
+
 	var _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; };
-	
+
 	var _slicedToArray = function () { function sliceIterator(arr, i) { var _arr = []; var _n = true; var _d = false; var _e = undefined; try { for (var _i = arr[Symbol.iterator](), _s; !(_n = (_s = _i.next()).done); _n = true) { _arr.push(_s.value); if (i && _arr.length === i) break; } } catch (err) { _d = true; _e = err; } finally { try { if (!_n && _i["return"]) _i["return"](); } finally { if (_d) throw _e; } } return _arr; } return function (arr, i) { if (Array.isArray(arr)) { return arr; } else if (Symbol.iterator in Object(arr)) { return sliceIterator(arr, i); } else { throw new TypeError("Invalid attempt to destructure non-iterable instance"); } }; }();
-	
+
 	var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
-	
+
 	var _react = __webpack_require__(2);
-	
+
 	var _react2 = _interopRequireDefault(_react);
-	
+
 	var _reactDom = __webpack_require__(3);
-	
+
 	var _reactDom2 = _interopRequireDefault(_reactDom);
-	
+
 	var _classnames = __webpack_require__(4);
-	
+
 	var _classnames2 = _interopRequireDefault(_classnames);
-	
+
 	var _domFns = __webpack_require__(5);
-	
+
 	var _positionFns = __webpack_require__(8);
-	
+
 	var _shims = __webpack_require__(6);
-	
+
 	var _DraggableCore = __webpack_require__(9);
-	
+
 	var _DraggableCore2 = _interopRequireDefault(_DraggableCore);
-	
+
 	var _log = __webpack_require__(11);
-	
+
 	var _log2 = _interopRequireDefault(_log);
-	
+
+	var _global = __webpack_require__(12);
+
+	var _global2 = _interopRequireDefault(_global);
+
 	function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
-	
+
 	function _defineProperty(obj, key, value) { if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
-	
+
 	function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
-	
+
 	function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return call && (typeof call === "object" || typeof call === "function") ? call : self; }
-	
+
 	function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
 	// $FlowIgnore
-	
-	
+
+
 	/*:: import type {DraggableEventHandler} from './utils/types';*/
 	/*:: type DraggableState = {
 	  dragging: boolean,
@@ -121,104 +125,102 @@ return /******/ (function(modules) { // webpackBootstrap
 	  slackX: number, slackY: number,
 	  isElementSVG: boolean
 	};*/
-	
-	
+
+
 	//
 	// Define <Draggable>
 	//
-	
+
 	/*:: type ConstructorProps = {
 	  position: { x: number, y: number },
 	  defaultPosition: { x: number, y: number }
 	};*/
-	
+
 	var Draggable = function (_React$Component) {
 	  _inherits(Draggable, _React$Component);
-	
+
 	  function Draggable(props /*: ConstructorProps*/) {
 	    _classCallCheck(this, Draggable);
-	
+
 	    var _this = _possibleConstructorReturn(this, Object.getPrototypeOf(Draggable).call(this, props));
-	
+
 	    _this.onDragStart = function (e, coreData) {
 	      (0, _log2.default)('Draggable: onDragStart: %j', coreData);
-	
+
 	      // Short-circuit if user's callback killed it.
 	      var shouldStart = _this.props.onStart(e, (0, _positionFns.createDraggableData)(_this, coreData));
 	      // Kills start event on core as well, so move handlers are never bound.
 	      if (shouldStart === false) return false;
-	
+
 	      _this.setState({ dragging: true, dragged: true });
 	    };
-	
+
 	    _this.onDrag = function (e, coreData) {
 	      if (!_this.state.dragging) return false;
 	      (0, _log2.default)('Draggable: onDrag: %j', coreData);
-	
+
 	      var uiData = (0, _positionFns.createDraggableData)(_this, coreData);
-	
+
 	      var newState /*: $Shape<DraggableState>*/ = {
 	        x: uiData.x,
 	        y: uiData.y
 	      };
-	
+
 	      // Keep within bounds.
 	      if (_this.props.bounds) {
 	        // Save original x and y.
 	        var _x = newState.x;
 	        var _y = newState.y;
-	
+
 	        // Add slack to the values used to calculate bound position. This will ensure that if
 	        // we start removing slack, the element won't react to it right away until it's been
 	        // completely removed.
-	
+
 	        newState.x += _this.state.slackX;
 	        newState.y += _this.state.slackY;
-	
+
 	        // Get bound position. This will ceil/floor the x and y within the boundaries.
 	        // $FlowBug
-	
-	
+
 	        // Recalculate slack by noting how much was shaved by the boundPosition handler.
-	
 	        var _getBoundPosition = (0, _positionFns.getBoundPosition)(_this, newState.x, newState.y);
-	
+
 	        var _getBoundPosition2 = _slicedToArray(_getBoundPosition, 2);
-	
+
 	        newState.x = _getBoundPosition2[0];
 	        newState.y = _getBoundPosition2[1];
 	        newState.slackX = _this.state.slackX + (_x - newState.x);
 	        newState.slackY = _this.state.slackY + (_y - newState.y);
-	
+
 	        // Update the event we fire to reflect what really happened after bounds took effect.
 	        uiData.x = _x;
 	        uiData.y = _y;
 	        uiData.deltaX = newState.x - _this.state.x;
 	        uiData.deltaY = newState.y - _this.state.y;
 	      }
-	
+
 	      // Short-circuit if user's callback killed it.
 	      var shouldUpdate = _this.props.onDrag(e, uiData);
 	      if (shouldUpdate === false) return false;
-	
+
 	      _this.setState(newState);
 	    };
-	
+
 	    _this.onDragStop = function (e, coreData) {
 	      if (!_this.state.dragging) return false;
-	
+
 	      // Short-circuit if user's callback killed it.
 	      var shouldStop = _this.props.onStop(e, (0, _positionFns.createDraggableData)(_this, coreData));
 	      if (shouldStop === false) return false;
-	
+
 	      (0, _log2.default)('Draggable: onDragStop: %j', coreData);
-	
+
 	      var newState /*: $Shape<DraggableState>*/ = {
 	        dragging: false,
 	        slackX: 0,
 	        slackY: 0
 	      };
-	
+
 	      // If this is a controlled component, the result of this operation will be to
 	      // revert back to the old position. We expect a handler on `onDragStop`, at the least.
 	      var controlled = Boolean(_this.props.position);
@@ -226,34 +228,34 @@ return /******/ (function(modules) { // webpackBootstrap
 	        var _this$props$position = _this.props.position;
 	        var _x2 = _this$props$position.x;
 	        var _y2 = _this$props$position.y;
-	
+
 	        newState.x = _x2;
 	        newState.y = _y2;
 	      }
-	
+
 	      _this.setState(newState);
 	    };
-	
+
 	    _this.state = {
 	      // Whether or not we are currently dragging.
 	      dragging: false,
-	
+
 	      // Whether or not we have been dragged before.
 	      dragged: false,
-	
+
 	      // Current transform x and y.
 	      x: props.position ? props.position.x : props.defaultPosition.x,
 	      y: props.position ? props.position.y : props.defaultPosition.y,
-	
+
 	      // Used for compensating for out-of-bounds drags
 	      slackX: 0, slackY: 0,
-	
+
 	      // Can only determine if SVG after mounting
 	      isElementSVG: false
 	    };
 	    return _this;
 	  }
-	
+
 	  _createClass(Draggable, [{
 	    key: 'componentWillMount',
 	    value: function componentWillMount() {
@@ -266,7 +268,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	    key: 'componentDidMount',
 	    value: function componentDidMount() {
 	      // Check to see if the element passed is an instanceof SVGElement
-	      if (typeof global.SVGElement !== 'undefined' && _reactDom2.default.findDOMNode(this) instanceof global.SVGElement) {
+	      if (typeof _global2.default.SVGElement !== 'undefined' && _reactDom2.default.findDOMNode(this) instanceof _global2.default.SVGElement) {
 	        this.setState({ isElementSVG: true });
 	      }
 	    }
@@ -287,23 +289,23 @@ return /******/ (function(modules) { // webpackBootstrap
 	    key: 'render',
 	    value: function render() {
 	      var _classNames;
-	
+
 	      var style = {},
 	          svgTransform = null;
-	
+
 	      // If this is controlled, we don't want to move it - unless it's dragging.
 	      var controlled = Boolean(this.props.position);
 	      var draggable = !controlled || this.state.dragging;
-	
+
 	      var position = this.props.position || this.props.defaultPosition;
 	      var transformOpts = {
 	        // Set left if horizontal drag is enabled
 	        x: (0, _positionFns.canDragX)(this) && draggable ? this.state.x : position.x,
-	
+
 	        // Set top if vertical drag is enabled
 	        y: (0, _positionFns.canDragY)(this) && draggable ? this.state.y : position.y
 	      };
-	
+
 	      // If this element was SVG, we use the `transform` attribute.
 	      if (this.state.isElementSVG) {
 	        svgTransform = (0, _domFns.createSVGTransform)(transformOpts);
@@ -314,16 +316,16 @@ return /******/ (function(modules) { // webpackBootstrap
 	        // has a clean slate.
 	        style = (0, _domFns.createCSSTransform)(transformOpts);
 	      }
-	
+
 	      var _props = this.props;
 	      var defaultClassName = _props.defaultClassName;
 	      var defaultClassNameDragging = _props.defaultClassNameDragging;
 	      var defaultClassNameDragged = _props.defaultClassNameDragged;
-	
+
 	      // Mark with class while dragging
-	
+
 	      var className = (0, _classnames2.default)(this.props.children.props.className || '', defaultClassName, (_classNames = {}, _defineProperty(_classNames, defaultClassNameDragging, this.state.dragging), _defineProperty(_classNames, defaultClassNameDragged, this.state.dragged), _classNames));
-	
+
 	      // Reuse the child provided
 	      // This makes it flexible to use whatever element is wanted (div, ul, etc)
 	      return _react2.default.createElement(
@@ -337,13 +339,13 @@ return /******/ (function(modules) { // webpackBootstrap
 	      );
 	    }
 	  }]);
-	
+
 	  return Draggable;
 	}(_react2.default.Component);
-	
+
 	Draggable.displayName = 'Draggable';
 	Draggable.propTypes = _extends({}, _DraggableCore2.default.propTypes, {
-	
+
 	  /**
 	   * `axis` determines which axis the draggable can move.
 	   *
@@ -358,7 +360,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	   * Defaults to 'both'.
 	   */
 	  axis: _react.PropTypes.oneOf(['both', 'x', 'y', 'none']),
-	
+
 	  /**
 	   * `bounds` determines the range of movement available to the element.
 	   * Available values are:
@@ -391,11 +393,11 @@ return /******/ (function(modules) { // webpackBootstrap
 	    top: _react.PropTypes.number,
 	    bottom: _react.PropTypes.number
 	  }), _react.PropTypes.string, _react.PropTypes.oneOf([false])]),
-	
+
 	  defaultClassName: _react.PropTypes.string,
 	  defaultClassNameDragging: _react.PropTypes.string,
 	  defaultClassNameDragged: _react.PropTypes.string,
-	
+
 	  /**
 	   * `defaultPosition` specifies the x and y that the dragged item should start at
 	   *
@@ -417,7 +419,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	    x: _react.PropTypes.number,
 	    y: _react.PropTypes.number
 	  }),
-	
+
 	  /**
 	   * `position`, if present, defines the current position of the element.
 	   *
@@ -442,7 +444,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	    x: _react.PropTypes.number,
 	    y: _react.PropTypes.number
 	  }),
-	
+
 	  /**
 	   * These properties should be defined on the child, not here.
 	   */
@@ -460,7 +462,6 @@ return /******/ (function(modules) { // webpackBootstrap
 	  position: null
 	});
 	exports.default = Draggable;
-	/* WEBPACK VAR INJECTION */}.call(exports, (function() { return this; }())))
 
 /***/ },
 /* 2 */
@@ -484,21 +485,21 @@ return /******/ (function(modules) { // webpackBootstrap
 	  http://jedwatson.github.io/classnames
 	*/
 	/* global define */
-	
+
 	(function () {
 		'use strict';
-	
+
 		var hasOwn = {}.hasOwnProperty;
-	
+
 		function classNames () {
 			var classes = [];
-	
+
 			for (var i = 0; i < arguments.length; i++) {
 				var arg = arguments[i];
 				if (!arg) continue;
-	
+
 				var argType = typeof arg;
-	
+
 				if (argType === 'string' || argType === 'number') {
 					classes.push(arg);
 				} else if (Array.isArray(arg)) {
@@ -511,10 +512,10 @@ return /******/ (function(modules) { // webpackBootstrap
 					}
 				}
 			}
-	
+
 			return classes.join(' ');
 		}
-	
+
 		if (typeof module !== 'undefined' && module.exports) {
 			module.exports = classNames;
 		} else if (true) {
@@ -533,13 +534,13 @@ return /******/ (function(modules) { // webpackBootstrap
 /***/ function(module, exports, __webpack_require__) {
 
 	'use strict';
-	
+
 	Object.defineProperty(exports, "__esModule", {
 	  value: true
 	});
-	
+
 	var _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; };
-	
+
 	exports.matchesSelector = matchesSelector;
 	exports.matchesSelectorAndParentsTo = matchesSelectorAndParentsTo;
 	exports.addEvent = addEvent;
@@ -556,20 +557,20 @@ return /******/ (function(modules) { // webpackBootstrap
 	exports.addUserSelectStyles = addUserSelectStyles;
 	exports.removeUserSelectStyles = removeUserSelectStyles;
 	exports.styleHacks = styleHacks;
-	
+
 	var _shims = __webpack_require__(6);
-	
+
 	var _getPrefix = __webpack_require__(7);
-	
+
 	var _getPrefix2 = _interopRequireDefault(_getPrefix);
-	
+
 	function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
-	
+
 	function _defineProperty(obj, key, value) { if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
-	
+
 	/*:: import type {ControlPosition} from './types';*/
-	
-	
+
+
 	var matchesSelectorFunc = '';
 	function matchesSelector(el /*: Node*/, selector /*: string*/) /*: boolean*/ {
 	  if (!matchesSelectorFunc) {
@@ -578,11 +579,11 @@ return /******/ (function(modules) { // webpackBootstrap
 	      return (0, _shims.isFunction)(el[method]);
 	    });
 	  }
-	
+
 	  // $FlowIgnore: Doesn't think elements are indexable
 	  return el[matchesSelectorFunc].call(el, selector);
 	}
-	
+
 	// Works up the tree to the draggable itself attempting to match selector.
 	function matchesSelectorAndParentsTo(el /*: Node*/, selector /*: string*/, baseNode /*: Node*/) /*: boolean*/ {
 	  var node = el;
@@ -591,10 +592,10 @@ return /******/ (function(modules) { // webpackBootstrap
 	    if (node === baseNode) return false;
 	    node = node.parentNode;
 	  } while (node);
-	
+
 	  return false;
 	}
-	
+
 	function addEvent(el /*: ?Node*/, event /*: string*/, handler /*: Function*/) /*: void*/ {
 	  if (!el) {
 	    return;
@@ -608,7 +609,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	    el['on' + event] = handler;
 	  }
 	}
-	
+
 	function removeEvent(el /*: ?Node*/, event /*: string*/, handler /*: Function*/) /*: void*/ {
 	  if (!el) {
 	    return;
@@ -622,7 +623,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	    el['on' + event] = null;
 	  }
 	}
-	
+
 	function outerHeight(node /*: HTMLElement*/) /*: number*/ {
 	  // This is deliberately excluding margin for our calculations, since we are using
 	  // offsetTop which is including margin. See getBoundPosition
@@ -632,7 +633,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	  height += (0, _shims.int)(computedStyle.borderBottomWidth);
 	  return height;
 	}
-	
+
 	function outerWidth(node /*: HTMLElement*/) /*: number*/ {
 	  // This is deliberately excluding margin for our calculations, since we are using
 	  // offsetLeft which is including margin. See getBoundPosition
@@ -649,7 +650,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	  height -= (0, _shims.int)(computedStyle.paddingBottom);
 	  return height;
 	}
-	
+
 	function innerWidth(node /*: HTMLElement*/) /*: number*/ {
 	  var width = node.clientWidth;
 	  var computedStyle = node.ownerDocument.defaultView.getComputedStyle(node);
@@ -657,33 +658,33 @@ return /******/ (function(modules) { // webpackBootstrap
 	  width -= (0, _shims.int)(computedStyle.paddingRight);
 	  return width;
 	}
-	
+
 	// Get from offsetParent
 	function offsetXYFromParent(evt /*: {clientX: number, clientY: number}*/, offsetParent /*: HTMLElement*/) /*: ControlPosition*/ {
 	  var isBody = offsetParent === offsetParent.ownerDocument.body;
 	  var offsetParentRect = isBody ? { left: 0, top: 0 } : offsetParent.getBoundingClientRect();
-	
+
 	  var x = evt.clientX + offsetParent.scrollLeft - offsetParentRect.left;
 	  var y = evt.clientY + offsetParent.scrollTop - offsetParentRect.top;
-	
+
 	  return { x: x, y: y };
 	}
-	
+
 	function createCSSTransform(_ref) /*: Object*/ {
 	  var x = _ref.x;
 	  var y = _ref.y;
-	
+
 	  // Replace unitless items with px
 	  return _defineProperty({}, (0, _getPrefix.browserPrefixToKey)('transform', _getPrefix2.default), 'translate(' + x + 'px,' + y + 'px)');
 	}
-	
+
 	function createSVGTransform(_ref3) /*: string*/ {
 	  var x = _ref3.x;
 	  var y = _ref3.y;
-	
+
 	  return 'translate(' + x + ',' + y + ')';
 	}
-	
+
 	function getTouch(e /*: MouseEvent*/, identifier /*: number*/) /*: ?{clientX: number, clientY: number}*/ {
 	  return e.targetTouches && (0, _shims.findInArray)(e.targetTouches, function (t) {
 	    return identifier === t.identifier;
@@ -691,33 +692,33 @@ return /******/ (function(modules) { // webpackBootstrap
 	    return identifier === t.identifier;
 	  });
 	}
-	
+
 	function getTouchIdentifier(e /*: MouseEvent*/) /*: ?number*/ {
 	  if (e.targetTouches && e.targetTouches[0]) return e.targetTouches[0].identifier;
 	  if (e.changedTouches && e.changedTouches[0]) return e.changedTouches[0].identifier;
 	}
-	
+
 	// User-select Hacks:
 	//
 	// Useful for preventing blue highlights all over everything when dragging.
 	var userSelectPrefix = (0, _getPrefix.getPrefix)('user-select');
 	var userSelect = (0, _getPrefix.browserPrefixToStyle)('user-select', userSelectPrefix);
 	var userSelectStyle = ';' + userSelect + ': none;';
-	
+
 	// Note we're passing `document` b/c we could be iframed
 	function addUserSelectStyles(body /*: HTMLElement*/) {
 	  var style = body.getAttribute('style') || '';
 	  body.setAttribute('style', style + userSelectStyle);
 	}
-	
+
 	function removeUserSelectStyles(body /*: HTMLElement*/) {
 	  var style = body.getAttribute('style') || '';
 	  body.setAttribute('style', style.replace(userSelectStyle, ''));
 	}
-	
+
 	function styleHacks() /*: Object*/ {
 	  var childStyle /*: Object*/ = arguments.length <= 0 || arguments[0] === undefined ? {} : arguments[0];
-	
+
 	  // Workaround IE pointer events; see #51
 	  // https://github.com/mzabriskie/react-draggable/issues/51#issuecomment-103488278
 	  return _extends({
@@ -730,7 +731,7 @@ return /******/ (function(modules) { // webpackBootstrap
 /***/ function(module, exports) {
 
 	'use strict';
-	
+
 	Object.defineProperty(exports, "__esModule", {
 	  value: true
 	});
@@ -739,26 +740,26 @@ return /******/ (function(modules) { // webpackBootstrap
 	exports.isNum = isNum;
 	exports.int = int;
 	exports.dontSetMe = dontSetMe;
-	
+
 	// @credits https://gist.github.com/rogozhnikoff/a43cfed27c41e4e68cdc
 	function findInArray(array /*: Array<any>*/, callback /*: Function*/) /*: any*/ {
 	  for (var i = 0, length = array.length; i < length; i++) {
 	    if (callback.apply(callback, [array[i], i, array])) return array[i];
 	  }
 	}
-	
+
 	function isFunction(func /*: any*/) /*: boolean*/ {
 	  return typeof func === 'function' || Object.prototype.toString.call(func) === '[object Function]';
 	}
-	
+
 	function isNum(num /*: any*/) /*: boolean*/ {
 	  return typeof num === 'number' && !isNaN(num);
 	}
-	
+
 	function int(a /*: string*/) /*: number*/ {
 	  return parseInt(a, 10);
 	}
-	
+
 	function dontSetMe(props /*: Object*/, propName /*: string*/, componentName /*: string*/) {
 	  if (props[propName]) {
 	    return new Error('Invalid prop ' + propName + ' passed to ' + componentName + ' - do not set this, set it on the child.');
@@ -770,42 +771,41 @@ return /******/ (function(modules) { // webpackBootstrap
 /***/ function(module, exports) {
 
 	'use strict';
-	
+
 	Object.defineProperty(exports, "__esModule", {
 	  value: true
 	});
 	exports.getPrefix = getPrefix;
 	exports.browserPrefixToKey = browserPrefixToKey;
 	exports.browserPrefixToStyle = browserPrefixToStyle;
-	
 	var prefixes = ['Moz', 'Webkit', 'O', 'ms'];
 	function getPrefix() /*: string*/ {
 	  var prop /*: string*/ = arguments.length <= 0 || arguments[0] === undefined ? 'transform' : arguments[0];
-	
+
 	  // Checking specifically for 'window.document' is for pseudo-browser server-side
 	  // environments that define 'window' as the global context.
 	  // E.g. React-rails (see https://github.com/reactjs/react-rails/pull/84)
 	  if (typeof window === 'undefined' || typeof window.document === 'undefined') return '';
-	
+
 	  var style = window.document.documentElement.style;
-	
+
 	  if (prop in style) return '';
-	
+
 	  for (var i = 0; i < prefixes.length; i++) {
 	    if (browserPrefixToKey(prop, prefixes[i]) in style) return prefixes[i];
 	  }
-	
+
 	  return '';
 	}
-	
+
 	function browserPrefixToKey(prop /*: string*/, prefix /*: string*/) /*: string*/ {
 	  return prefix ? '' + prefix + kebabToTitleCase(prop) : prop;
 	}
-	
+
 	function browserPrefixToStyle(prop /*: string*/, prefix /*: string*/) /*: string*/ {
 	  return prefix ? '-' + prefix.toLowerCase() + '-' + prop : prop;
 	}
-	
+
 	function kebabToTitleCase(str /*: string*/) /*: string*/ {
 	  var out = '';
 	  var shouldCapitalize = true;
@@ -821,7 +821,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	  }
 	  return out;
 	}
-	
+
 	// Default export is the prefix itself, like 'Moz', 'Webkit', etc
 	// Note that you may have to re-test for certain things; for instance, Chrome 50
 	// can handle unprefixed `transform`, but not unprefixed `user-select`
@@ -832,7 +832,7 @@ return /******/ (function(modules) { // webpackBootstrap
 /***/ function(module, exports, __webpack_require__) {
 
 	'use strict';
-	
+
 	Object.defineProperty(exports, "__esModule", {
 	  value: true
 	});
@@ -843,33 +843,33 @@ return /******/ (function(modules) { // webpackBootstrap
 	exports.getControlPosition = getControlPosition;
 	exports.createCoreData = createCoreData;
 	exports.createDraggableData = createDraggableData;
-	
+
 	var _shims = __webpack_require__(6);
-	
+
 	var _reactDom = __webpack_require__(3);
-	
+
 	var _reactDom2 = _interopRequireDefault(_reactDom);
-	
+
 	var _domFns = __webpack_require__(5);
-	
+
 	function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
-	
+
 	/*:: import type Draggable from '../Draggable';*/
 	/*:: import type {Bounds, ControlPosition, DraggableData} from './types';*/
 	/*:: import type DraggableCore from '../DraggableCore';*/
 	function getBoundPosition(draggable /*: Draggable*/, x /*: number*/, y /*: number*/) /*: [number, number]*/ {
 	  // If no bounds, short-circuit and move on
 	  if (!draggable.props.bounds) return [x, y];
-	
+
 	  // Clone new bounds
 	  var bounds = draggable.props.bounds;
-	
+
 	  bounds = typeof bounds === 'string' ? bounds : cloneBounds(bounds);
 	  var node = _reactDom2.default.findDOMNode(draggable);
-	
+
 	  if (typeof bounds === 'string') {
 	    var ownerDocument = node.ownerDocument;
-	
+
 	    var ownerWindow = ownerDocument.defaultView;
 	    var boundNode = void 0;
 	    if (bounds === 'parent') {
@@ -888,32 +888,32 @@ return /******/ (function(modules) { // webpackBootstrap
 	      bottom: (0, _domFns.innerHeight)(boundNode) - (0, _domFns.outerHeight)(node) - node.offsetTop
 	    };
 	  }
-	
+
 	  // Keep x and y below right and bottom limits...
 	  if ((0, _shims.isNum)(bounds.right)) x = Math.min(x, bounds.right);
 	  if ((0, _shims.isNum)(bounds.bottom)) y = Math.min(y, bounds.bottom);
-	
+
 	  // But above left and top limits.
 	  if ((0, _shims.isNum)(bounds.left)) x = Math.max(x, bounds.left);
 	  if ((0, _shims.isNum)(bounds.top)) y = Math.max(y, bounds.top);
-	
+
 	  return [x, y];
 	}
-	
+
 	function snapToGrid(grid /*: [number, number]*/, pendingX /*: number*/, pendingY /*: number*/) /*: [number, number]*/ {
 	  var x = Math.round(pendingX / grid[0]) * grid[0];
 	  var y = Math.round(pendingY / grid[1]) * grid[1];
 	  return [x, y];
 	}
-	
+
 	function canDragX(draggable /*: Draggable*/) /*: boolean*/ {
 	  return draggable.props.axis === 'both' || draggable.props.axis === 'x';
 	}
-	
+
 	function canDragY(draggable /*: Draggable*/) /*: boolean*/ {
 	  return draggable.props.axis === 'both' || draggable.props.axis === 'y';
 	}
-	
+
 	// Get {x, y} positions from event.
 	function getControlPosition(e /*: MouseEvent*/, touchIdentifier /*: ?number*/, draggableCore /*: DraggableCore*/) /*: ?ControlPosition*/ {
 	  var touchObj = typeof touchIdentifier === 'number' ? (0, _domFns.getTouch)(e, touchIdentifier) : null;
@@ -923,13 +923,13 @@ return /******/ (function(modules) { // webpackBootstrap
 	  var offsetParent = draggableCore.props.offsetParent || node.offsetParent || node.ownerDocument.body;
 	  return (0, _domFns.offsetXYFromParent)(touchObj || e, offsetParent);
 	}
-	
+
 	// Create an data object exposed by <DraggableCore>'s events
 	function createCoreData(draggable /*: DraggableCore*/, x /*: number*/, y /*: number*/) /*: DraggableData*/ {
 	  // State changes are often (but not always!) async. We want the latest value.
 	  var state = draggable._pendingState || draggable.state;
 	  var isStart = !(0, _shims.isNum)(state.lastX);
-	
+
 	  if (isStart) {
 	    // If this is our first move, use the x and y as last coords.
 	    return {
@@ -948,7 +948,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	    };
 	  }
 	}
-	
+
 	// Create an data exposed by <Draggable>'s events
 	function createDraggableData(draggable /*: Draggable*/, coreData /*: DraggableData*/) /*: DraggableData*/ {
 	  return {
@@ -961,7 +961,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	    lastY: draggable.state.y
 	  };
 	}
-	
+
 	// A lot faster than stringify/parse
 	function cloneBounds(bounds /*: Bounds*/) /*: Bounds*/ {
 	  return {
@@ -977,41 +977,41 @@ return /******/ (function(modules) { // webpackBootstrap
 /***/ function(module, exports, __webpack_require__) {
 
 	/* WEBPACK VAR INJECTION */(function(process) {'use strict';
-	
+
 	Object.defineProperty(exports, "__esModule", {
 	  value: true
 	});
-	
+
 	var _slicedToArray = function () { function sliceIterator(arr, i) { var _arr = []; var _n = true; var _d = false; var _e = undefined; try { for (var _i = arr[Symbol.iterator](), _s; !(_n = (_s = _i.next()).done); _n = true) { _arr.push(_s.value); if (i && _arr.length === i) break; } } catch (err) { _d = true; _e = err; } finally { try { if (!_n && _i["return"]) _i["return"](); } finally { if (_d) throw _e; } } return _arr; } return function (arr, i) { if (Array.isArray(arr)) { return arr; } else if (Symbol.iterator in Object(arr)) { return sliceIterator(arr, i); } else { throw new TypeError("Invalid attempt to destructure non-iterable instance"); } }; }();
-	
+
 	var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
-	
+
 	var _react = __webpack_require__(2);
-	
+
 	var _react2 = _interopRequireDefault(_react);
-	
+
 	var _reactDom = __webpack_require__(3);
-	
+
 	var _reactDom2 = _interopRequireDefault(_reactDom);
-	
+
 	var _domFns = __webpack_require__(5);
-	
+
 	var _positionFns = __webpack_require__(8);
-	
+
 	var _shims = __webpack_require__(6);
-	
+
 	var _log = __webpack_require__(11);
-	
+
 	var _log2 = _interopRequireDefault(_log);
-	
+
 	function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
-	
+
 	function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
-	
+
 	function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return call && (typeof call === "object" || typeof call === "function") ? call : self; }
-	
+
 	function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
-	
+
 	// Simple abstraction for dragging events names.
 	/*:: import type {EventHandler} from './utils/types';*/
 	var eventsFor = {
@@ -1026,38 +1026,38 @@ return /******/ (function(modules) { // webpackBootstrap
 	    stop: 'mouseup'
 	  }
 	};
-	
+
 	// Default to mouse events.
 	var dragEventFor = eventsFor.mouse;
-	
+
 	//
 	// Define <DraggableCore>.
 	//
 	// <DraggableCore> is for advanced usage of <Draggable>. It maintains minimal internal state so it can
 	// work well with libraries that require more control over the element.
 	//
-	
+
 	/*:: type CoreState = {
 	  dragging: boolean,
 	  lastX: number,
 	  lastY: number,
 	  touchIdentifier: ?number
 	};*/
-	
+
 	var DraggableCore = function (_React$Component) {
 	  _inherits(DraggableCore, _React$Component);
-	
+
 	  function DraggableCore() {
 	    var _Object$getPrototypeO;
-	
+
 	    var _temp, _this, _ret;
-	
+
 	    _classCallCheck(this, DraggableCore);
-	
+
 	    for (var _len = arguments.length, args = Array(_len), _key = 0; _key < _len; _key++) {
 	      args[_key] = arguments[_key];
 	    }
-	
+
 	    return _ret = (_temp = (_this = _possibleConstructorReturn(this, (_Object$getPrototypeO = Object.getPrototypeOf(DraggableCore)).call.apply(_Object$getPrototypeO, [this].concat(args))), _this), _this.state = {
 	      dragging: false,
 	      // Used while dragging to determine deltas.
@@ -1066,93 +1066,93 @@ return /******/ (function(modules) { // webpackBootstrap
 	    }, _this.handleDragStart = function (e) {
 	      // Make it possible to attach event handlers on top of this one.
 	      _this.props.onMouseDown(e);
-	
+
 	      // Only accept left-clicks.
 	      if (!_this.props.allowAnyClick && typeof e.button === 'number' && e.button !== 0) return false;
-	
+
 	      // Get nodes. Be sure to grab relative document (could be iframed)
 	      var domNode = _reactDom2.default.findDOMNode(_this);
 	      var ownerDocument = domNode.ownerDocument;
-	
+
 	      // Short circuit if handle or cancel prop was provided and selector doesn't match.
-	
+
 	      if (_this.props.disabled || !(e.target instanceof ownerDocument.defaultView.Node) || _this.props.handle && !(0, _domFns.matchesSelectorAndParentsTo)(e.target, _this.props.handle, domNode) || _this.props.cancel && (0, _domFns.matchesSelectorAndParentsTo)(e.target, _this.props.cancel, domNode)) {
 	        return;
 	      }
-	
+
 	      // Set touch identifier in component state if this is a touch event. This allows us to
 	      // distinguish between individual touches on multitouch screens by identifying which
 	      // touchpoint was set to this element.
 	      var touchIdentifier = (0, _domFns.getTouchIdentifier)(e);
 	      _this.setState({ touchIdentifier: touchIdentifier });
-	
+
 	      // Get the current drag point from the event. This is used as the offset.
 	      var position = (0, _positionFns.getControlPosition)(e, touchIdentifier, _this);
 	      if (position == null) return; // not possible but satisfies flow
 	      var x = position.x;
 	      var y = position.y;
-	
+
 	      // Create an event object with all the data parents need to make a decision here.
-	
+
 	      var coreEvent = (0, _positionFns.createCoreData)(_this, x, y);
-	
+
 	      (0, _log2.default)('DraggableCore: handleDragStart: %j', coreEvent);
-	
+
 	      // Call event handler. If it returns explicit false, cancel.
 	      (0, _log2.default)('calling', _this.props.onStart);
 	      var shouldUpdate = _this.props.onStart(e, coreEvent);
 	      if (shouldUpdate === false) return;
-	
+
 	      // Add a style to the body to disable user-select. This prevents text from
 	      // being selected all over the page.
 	      if (_this.props.enableUserSelectHack) (0, _domFns.addUserSelectStyles)(ownerDocument.body);
-	
+
 	      // Initiate dragging. Set the current x and y as offsets
 	      // so we know how much we've moved during the drag. This allows us
 	      // to drag elements around even if they have been moved, without issue.
 	      _this.setState({
 	        dragging: true,
-	
+
 	        lastX: x,
 	        lastY: y
 	      });
-	
+
 	      // Add events to the document directly so we catch when the user's mouse/touch moves outside of
 	      // this element. We use different events depending on whether or not we have detected that this
 	      // is a touch-capable device.
 	      (0, _domFns.addEvent)(ownerDocument, dragEventFor.move, _this.handleDrag);
 	      (0, _domFns.addEvent)(ownerDocument, dragEventFor.stop, _this.handleDragStop);
 	    }, _this.handleDrag = function (e) {
-	
+
 	      // Get the current drag point from the event. This is used as the offset.
 	      var position = (0, _positionFns.getControlPosition)(e, _this.state.touchIdentifier, _this);
 	      if (position == null) return;
 	      var x = position.x;
 	      var y = position.y;
-	
+
 	      // Snap to grid if prop has been provided
-	
+
 	      if (x !== x) debugger;
-	
+
 	      if (Array.isArray(_this.props.grid)) {
 	        var deltaX = x - _this.state.lastX,
 	            deltaY = y - _this.state.lastY;
-	
+
 	        var _snapToGrid = (0, _positionFns.snapToGrid)(_this.props.grid, deltaX, deltaY);
-	
+
 	        var _snapToGrid2 = _slicedToArray(_snapToGrid, 2);
-	
+
 	        deltaX = _snapToGrid2[0];
 	        deltaY = _snapToGrid2[1];
-	
+
 	        if (!deltaX && !deltaY) return; // skip useless drag
 	        x = _this.state.lastX + deltaX, y = _this.state.lastY + deltaY;
 	      }
-	
+
 	      var coreEvent = (0, _positionFns.createCoreData)(_this, x, y);
-	
+
 	      (0, _log2.default)('DraggableCore: handleDrag: %j', coreEvent);
-	
+
 	      // Call event handler. If it returns explicit false, trigger end.
 	      var shouldUpdate = _this.props.onDrag(e, coreEvent);
 	      if (shouldUpdate === false) {
@@ -1168,85 +1168,84 @@ return /******/ (function(modules) { // webpackBootstrap
 	        }
 	        return;
 	      }
-	
+
 	      _this.setState({
 	        lastX: x,
 	        lastY: y
 	      });
 	    }, _this.handleDragStop = function (e) {
 	      if (!_this.state.dragging) return;
-	
+
 	      var position = (0, _positionFns.getControlPosition)(e, _this.state.touchIdentifier, _this);
 	      if (position == null) return;
 	      var x = position.x;
 	      var y = position.y;
-	
+
 	      var coreEvent = (0, _positionFns.createCoreData)(_this, x, y);
-	
+
 	      // Remove user-select hack
 	      if (_this.props.enableUserSelectHack) (0, _domFns.removeUserSelectStyles)(_reactDom2.default.findDOMNode(_this).ownerDocument.body);
-	
+
 	      (0, _log2.default)('DraggableCore: handleDragStop: %j', coreEvent);
-	
+
 	      // Reset the el.
 	      _this.setState({
 	        dragging: false,
 	        lastX: NaN,
 	        lastY: NaN
 	      });
-	
+
 	      // Call event handler
 	      _this.props.onStop(e, coreEvent);
-	
+
 	      // Remove event handlers
-	
+
 	      var _ReactDOM$findDOMNode = _reactDom2.default.findDOMNode(_this);
-	
+
 	      var ownerDocument = _ReactDOM$findDOMNode.ownerDocument;
-	
+
 	      (0, _log2.default)('DraggableCore: Removing handlers');
 	      (0, _domFns.removeEvent)(ownerDocument, dragEventFor.move, _this.handleDrag);
 	      (0, _domFns.removeEvent)(ownerDocument, dragEventFor.stop, _this.handleDragStop);
 	    }, _this.onMouseDown = function (e) {
 	      dragEventFor = eventsFor.mouse; // on touchscreen laptops we could switch back to mouse
-	
+
 	      return _this.handleDragStart(e);
 	    }, _this.onMouseUp = function (e) {
 	      dragEventFor = eventsFor.mouse;
-	
+
 	      return _this.handleDragStop(e);
 	    }, _this.onTouchStart = function (e) {
 	      // We're on a touch device now, so change the event handlers
 	      dragEventFor = eventsFor.touch;
-	
+
 	      return _this.handleDragStart(e);
 	    }, _this.onTouchEnd = function (e) {
 	      // We're on a touch device now, so change the event handlers
 	      dragEventFor = eventsFor.touch;
-	
+
 	      return _this.handleDragStop(e);
 	    }, _temp), _possibleConstructorReturn(_this, _ret);
 	  }
-	
+
 	  _createClass(DraggableCore, [{
 	    key: 'componentWillUnmount',
 	    value: function componentWillUnmount() {
 	      // Remove any leftover event handlers. Remove both touch and mouse handlers in case
 	      // some browser quirk caused a touch event to fire during a mouse move, or vice versa.
-	
 	      var _ReactDOM$findDOMNode2 = _reactDom2.default.findDOMNode(this);
-	
+
 	      var ownerDocument = _ReactDOM$findDOMNode2.ownerDocument;
-	
+
 	      (0, _domFns.removeEvent)(ownerDocument, eventsFor.mouse.move, this.handleDrag);
 	      (0, _domFns.removeEvent)(ownerDocument, eventsFor.touch.move, this.handleDrag);
 	      (0, _domFns.removeEvent)(ownerDocument, eventsFor.mouse.stop, this.handleDragStop);
 	      (0, _domFns.removeEvent)(ownerDocument, eventsFor.touch.stop, this.handleDragStop);
 	      if (this.props.enableUserSelectHack) (0, _domFns.removeUserSelectStyles)(ownerDocument.body);
 	    }
-	
+
 	    // Same as onMouseDown (start drag), but now consider this a touch device.
-	
+
 	  }, {
 	    key: 'render',
 	    value: function render() {
@@ -1254,7 +1253,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	      // This makes it flexible to use whatever element is wanted (div, ul, etc)
 	      return _react2.default.cloneElement(_react2.default.Children.only(this.props.children), {
 	        style: (0, _domFns.styleHacks)(this.props.children.props.style),
-	
+
 	        // Note: mouseMove handler is attached to document so it will still function
 	        // when the user drags quickly and leaves the bounds of the element.
 	        onMouseDown: this.onMouseDown,
@@ -1264,10 +1263,10 @@ return /******/ (function(modules) { // webpackBootstrap
 	      });
 	    }
 	  }]);
-	
+
 	  return DraggableCore;
 	}(_react2.default.Component);
-	
+
 	DraggableCore.displayName = 'DraggableCore';
 	DraggableCore.propTypes = {
 	  /**
@@ -1277,20 +1276,20 @@ return /******/ (function(modules) { // webpackBootstrap
 	   * Defaults to `false`.
 	   */
 	  allowAnyClick: _react.PropTypes.bool,
-	
+
 	  /**
 	   * `disabled`, if true, stops the <Draggable> from dragging. All handlers,
 	   * with the exception of `onMouseDown`, will not fire.
 	   */
 	  disabled: _react.PropTypes.bool,
-	
+
 	  /**
 	   * By default, we add 'user-select:none' attributes to the document body
 	   * to prevent ugly text selection during drag. If this is causing problems
 	   * for your app, set this to `false`.
 	   */
 	  enableUserSelectHack: _react.PropTypes.bool,
-	
+
 	  /**
 	   * `offsetParent`, if set, uses the passed DOM node to compute drag offsets
 	   * instead of using the parent node.
@@ -1300,12 +1299,12 @@ return /******/ (function(modules) { // webpackBootstrap
 	      throw new Error('Draggable\'s offsetParent must be a DOM Node.');
 	    }
 	  },
-	
+
 	  /**
 	   * `grid` specifies the x and y that dragging should snap to.
 	   */
 	  grid: _react.PropTypes.arrayOf(_react.PropTypes.number),
-	
+
 	  /**
 	   * `handle` specifies a selector to be used as the handle that initiates drag.
 	   *
@@ -1327,7 +1326,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	   * ```
 	   */
 	  handle: _react.PropTypes.string,
-	
+
 	  /**
 	   * `cancel` specifies a selector to be used to prevent drag initialization.
 	   *
@@ -1349,31 +1348,31 @@ return /******/ (function(modules) { // webpackBootstrap
 	   * ```
 	   */
 	  cancel: _react.PropTypes.string,
-	
+
 	  /**
 	   * Called when dragging starts.
 	   * If this function returns the boolean false, dragging will be canceled.
 	   */
 	  onStart: _react.PropTypes.func,
-	
+
 	  /**
 	   * Called while dragging.
 	   * If this function returns the boolean false, dragging will be canceled.
 	   */
 	  onDrag: _react.PropTypes.func,
-	
+
 	  /**
 	   * Called when dragging stops.
 	   * If this function returns the boolean false, the drag will remain active.
 	   */
 	  onStop: _react.PropTypes.func,
-	
+
 	  /**
 	   * A workaround option which can be passed if onMouseDown needs to be accessed,
 	   * since it'll always be blocked (as there is internal use of onMouseDown)
 	   */
 	  onMouseDown: _react.PropTypes.func,
-	
+
 	  /**
 	   * These properties should be defined on the child, not here.
 	   */
@@ -1403,38 +1402,79 @@ return /******/ (function(modules) { // webpackBootstrap
 /***/ function(module, exports) {
 
 	// shim for using process in browser
-	
 	var process = module.exports = {};
-	
+
 	// cached from whatever global is present so that test runners that stub it
 	// don't break things.  But we need to wrap it in a try catch in case it is
 	// wrapped in strict mode code which doesn't define any globals.  It's inside a
 	// function because try/catches deoptimize in certain engines.
-	
+
 	var cachedSetTimeout;
 	var cachedClearTimeout;
-	
+
 	(function () {
-	  try {
-	    cachedSetTimeout = setTimeout;
-	  } catch (e) {
-	    cachedSetTimeout = function () {
-	      throw new Error('setTimeout is not defined');
+	    try {
+	        cachedSetTimeout = setTimeout;
+	    } catch (e) {
+	        cachedSetTimeout = function () {
+	            throw new Error('setTimeout is not defined');
+	        }
 	    }
-	  }
-	  try {
-	    cachedClearTimeout = clearTimeout;
-	  } catch (e) {
-	    cachedClearTimeout = function () {
-	      throw new Error('clearTimeout is not defined');
+	    try {
+	        cachedClearTimeout = clearTimeout;
+	    } catch (e) {
+	        cachedClearTimeout = function () {
+	            throw new Error('clearTimeout is not defined');
+	        }
 	    }
-	  }
 	} ())
+	function runTimeout(fun) {
+	    if (cachedSetTimeout === setTimeout) {
+	        //normal enviroments in sane situations
+	        return setTimeout(fun, 0);
+	    }
+	    try {
+	        // when when somebody has screwed with setTimeout but no I.E. maddness
+	        return cachedSetTimeout(fun, 0);
+	    } catch(e){
+	        try {
+	            // When we are in I.E. but the script has been evaled so I.E. doesn't trust the global object when called normally
+	            return cachedSetTimeout.call(null, fun, 0);
+	        } catch(e){
+	            // same as above but when it's a version of I.E. that must have the global object for 'this', hopfully our context correct otherwise it will throw a global error
+	            return cachedSetTimeout.call(this, fun, 0);
+	        }
+	    }
+
+
+	}
+	function runClearTimeout(marker) {
+	    if (cachedClearTimeout === clearTimeout) {
+	        //normal enviroments in sane situations
+	        return clearTimeout(marker);
+	    }
+	    try {
+	        // when when somebody has screwed with setTimeout but no I.E. maddness
+	        return cachedClearTimeout(marker);
+	    } catch (e){
+	        try {
+	            // When we are in I.E. but the script has been evaled so I.E. doesn't  trust the global object when called normally
+	            return cachedClearTimeout.call(null, marker);
+	        } catch (e){
+	            // same as above but when it's a version of I.E. that must have the global object for 'this', hopfully our context correct otherwise it will throw a global error.
+	            // Some versions of I.E. have different rules for clearTimeout vs setTimeout
+	            return cachedClearTimeout.call(this, marker);
+	        }
+	    }
+
+
+
+	}
 	var queue = [];
 	var draining = false;
 	var currentQueue;
 	var queueIndex = -1;
-	
+
 	function cleanUpNextTick() {
 	    if (!draining || !currentQueue) {
 	        return;
@@ -1449,14 +1489,14 @@ return /******/ (function(modules) { // webpackBootstrap
 	        drainQueue();
 	    }
 	}
-	
+
 	function drainQueue() {
 	    if (draining) {
 	        return;
 	    }
-	    var timeout = cachedSetTimeout(cleanUpNextTick);
+	    var timeout = runTimeout(cleanUpNextTick);
 	    draining = true;
-	
+
 	    var len = queue.length;
 	    while(len) {
 	        currentQueue = queue;
@@ -1471,9 +1511,9 @@ return /******/ (function(modules) { // webpackBootstrap
 	    }
 	    currentQueue = null;
 	    draining = false;
-	    cachedClearTimeout(timeout);
+	    runClearTimeout(timeout);
 	}
-	
+
 	process.nextTick = function (fun) {
 	    var args = new Array(arguments.length - 1);
 	    if (arguments.length > 1) {
@@ -1483,10 +1523,10 @@ return /******/ (function(modules) { // webpackBootstrap
 	    }
 	    queue.push(new Item(fun, args));
 	    if (queue.length === 1 && !draining) {
-	        cachedSetTimeout(drainQueue, 0);
+	        runTimeout(drainQueue);
 	    }
 	};
-	
+
 	// v8 likes predictible objects
 	function Item(fun, array) {
 	    this.fun = fun;
@@ -1501,9 +1541,9 @@ return /******/ (function(modules) { // webpackBootstrap
 	process.argv = [];
 	process.version = ''; // empty string to avoid regexp issues
 	process.versions = {};
-	
+
 	function noop() {}
-	
+
 	process.on = noop;
 	process.addListener = noop;
 	process.once = noop;
@@ -1511,11 +1551,11 @@ return /******/ (function(modules) { // webpackBootstrap
 	process.removeListener = noop;
 	process.removeAllListeners = noop;
 	process.emit = noop;
-	
+
 	process.binding = function (name) {
 	    throw new Error('process.binding is not supported');
 	};
-	
+
 	process.cwd = function () { return '/' };
 	process.chdir = function (dir) {
 	    throw new Error('process.chdir is not supported');
@@ -1528,21 +1568,36 @@ return /******/ (function(modules) { // webpackBootstrap
 /***/ function(module, exports, __webpack_require__) {
 
 	"use strict";
-	
+
 	Object.defineProperty(exports, "__esModule", {
 	  value: true
 	});
 	exports.default = log;
-	
+
 	/*eslint no-console:0*/
 	function log() {
 	  var _console;
-	
+
 	  if ((undefined)) (_console = console).log.apply(_console, arguments);
 	}
+
+/***/ },
+/* 12 */
+/***/ function(module, exports) {
+
+	/* WEBPACK VAR INJECTION */(function(global) {if (typeof window !== "undefined") {
+	    module.exports = window;
+	} else if (typeof global !== "undefined") {
+	    module.exports = global;
+	} else if (typeof self !== "undefined"){
+	    module.exports = self;
+	} else {
+	    module.exports = {};
+	}
+
+	/* WEBPACK VAR INJECTION */}.call(exports, (function() { return this; }())))
 
 /***/ }
 /******/ ])
 });
 ;
-//# sourceMappingURL=react-draggable.js.map

--- a/dist/react-draggable.js
+++ b/dist/react-draggable.js
@@ -11,41 +11,41 @@
 return /******/ (function(modules) { // webpackBootstrap
 /******/ 	// The module cache
 /******/ 	var installedModules = {};
-
+/******/
 /******/ 	// The require function
 /******/ 	function __webpack_require__(moduleId) {
-
+/******/
 /******/ 		// Check if module is in cache
 /******/ 		if(installedModules[moduleId])
 /******/ 			return installedModules[moduleId].exports;
-
+/******/
 /******/ 		// Create a new module (and put it into the cache)
 /******/ 		var module = installedModules[moduleId] = {
 /******/ 			exports: {},
 /******/ 			id: moduleId,
 /******/ 			loaded: false
 /******/ 		};
-
+/******/
 /******/ 		// Execute the module function
 /******/ 		modules[moduleId].call(module.exports, module, module.exports, __webpack_require__);
-
+/******/
 /******/ 		// Flag the module as loaded
 /******/ 		module.loaded = true;
-
+/******/
 /******/ 		// Return the exports of the module
 /******/ 		return module.exports;
 /******/ 	}
-
-
+/******/
+/******/
 /******/ 	// expose the modules object (__webpack_modules__)
 /******/ 	__webpack_require__.m = modules;
-
+/******/
 /******/ 	// expose the module cache
 /******/ 	__webpack_require__.c = installedModules;
-
+/******/
 /******/ 	// __webpack_public_path__
 /******/ 	__webpack_require__.p = "";
-
+/******/
 /******/ 	// Load entry module and return exports
 /******/ 	return __webpack_require__(0);
 /******/ })
@@ -55,7 +55,7 @@ return /******/ (function(modules) { // webpackBootstrap
 /***/ function(module, exports, __webpack_require__) {
 
 	'use strict';
-
+	
 	module.exports = __webpack_require__(1).default;
 	module.exports.DraggableCore = __webpack_require__(9).default;
 
@@ -63,60 +63,56 @@ return /******/ (function(modules) { // webpackBootstrap
 /* 1 */
 /***/ function(module, exports, __webpack_require__) {
 
-	'use strict';
-
+	/* WEBPACK VAR INJECTION */(function(global) {'use strict';
+	
 	Object.defineProperty(exports, "__esModule", {
 	  value: true
 	});
-
+	
 	var _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; };
-
+	
 	var _slicedToArray = function () { function sliceIterator(arr, i) { var _arr = []; var _n = true; var _d = false; var _e = undefined; try { for (var _i = arr[Symbol.iterator](), _s; !(_n = (_s = _i.next()).done); _n = true) { _arr.push(_s.value); if (i && _arr.length === i) break; } } catch (err) { _d = true; _e = err; } finally { try { if (!_n && _i["return"]) _i["return"](); } finally { if (_d) throw _e; } } return _arr; } return function (arr, i) { if (Array.isArray(arr)) { return arr; } else if (Symbol.iterator in Object(arr)) { return sliceIterator(arr, i); } else { throw new TypeError("Invalid attempt to destructure non-iterable instance"); } }; }();
-
+	
 	var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
-
+	
 	var _react = __webpack_require__(2);
-
+	
 	var _react2 = _interopRequireDefault(_react);
-
+	
 	var _reactDom = __webpack_require__(3);
-
+	
 	var _reactDom2 = _interopRequireDefault(_reactDom);
-
+	
 	var _classnames = __webpack_require__(4);
-
+	
 	var _classnames2 = _interopRequireDefault(_classnames);
-
+	
 	var _domFns = __webpack_require__(5);
-
+	
 	var _positionFns = __webpack_require__(8);
-
+	
 	var _shims = __webpack_require__(6);
-
+	
 	var _DraggableCore = __webpack_require__(9);
-
+	
 	var _DraggableCore2 = _interopRequireDefault(_DraggableCore);
-
+	
 	var _log = __webpack_require__(11);
-
+	
 	var _log2 = _interopRequireDefault(_log);
-
-	var _global = __webpack_require__(12);
-
-	var _global2 = _interopRequireDefault(_global);
-
+	
 	function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
-
+	
 	function _defineProperty(obj, key, value) { if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
-
+	
 	function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
-
+	
 	function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return call && (typeof call === "object" || typeof call === "function") ? call : self; }
-
+	
 	function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
 	// $FlowIgnore
-
-
+	
+	
 	/*:: import type {DraggableEventHandler} from './utils/types';*/
 	/*:: type DraggableState = {
 	  dragging: boolean,
@@ -125,102 +121,104 @@ return /******/ (function(modules) { // webpackBootstrap
 	  slackX: number, slackY: number,
 	  isElementSVG: boolean
 	};*/
-
-
+	
+	
 	//
 	// Define <Draggable>
 	//
-
+	
 	/*:: type ConstructorProps = {
 	  position: { x: number, y: number },
 	  defaultPosition: { x: number, y: number }
 	};*/
-
+	
 	var Draggable = function (_React$Component) {
 	  _inherits(Draggable, _React$Component);
-
+	
 	  function Draggable(props /*: ConstructorProps*/) {
 	    _classCallCheck(this, Draggable);
-
+	
 	    var _this = _possibleConstructorReturn(this, Object.getPrototypeOf(Draggable).call(this, props));
-
+	
 	    _this.onDragStart = function (e, coreData) {
 	      (0, _log2.default)('Draggable: onDragStart: %j', coreData);
-
+	
 	      // Short-circuit if user's callback killed it.
 	      var shouldStart = _this.props.onStart(e, (0, _positionFns.createDraggableData)(_this, coreData));
 	      // Kills start event on core as well, so move handlers are never bound.
 	      if (shouldStart === false) return false;
-
+	
 	      _this.setState({ dragging: true, dragged: true });
 	    };
-
+	
 	    _this.onDrag = function (e, coreData) {
 	      if (!_this.state.dragging) return false;
 	      (0, _log2.default)('Draggable: onDrag: %j', coreData);
-
+	
 	      var uiData = (0, _positionFns.createDraggableData)(_this, coreData);
-
+	
 	      var newState /*: $Shape<DraggableState>*/ = {
 	        x: uiData.x,
 	        y: uiData.y
 	      };
-
+	
 	      // Keep within bounds.
 	      if (_this.props.bounds) {
 	        // Save original x and y.
 	        var _x = newState.x;
 	        var _y = newState.y;
-
+	
 	        // Add slack to the values used to calculate bound position. This will ensure that if
 	        // we start removing slack, the element won't react to it right away until it's been
 	        // completely removed.
-
+	
 	        newState.x += _this.state.slackX;
 	        newState.y += _this.state.slackY;
-
+	
 	        // Get bound position. This will ceil/floor the x and y within the boundaries.
 	        // $FlowBug
-
+	
+	
 	        // Recalculate slack by noting how much was shaved by the boundPosition handler.
+	
 	        var _getBoundPosition = (0, _positionFns.getBoundPosition)(_this, newState.x, newState.y);
-
+	
 	        var _getBoundPosition2 = _slicedToArray(_getBoundPosition, 2);
-
+	
 	        newState.x = _getBoundPosition2[0];
 	        newState.y = _getBoundPosition2[1];
 	        newState.slackX = _this.state.slackX + (_x - newState.x);
 	        newState.slackY = _this.state.slackY + (_y - newState.y);
-
+	
 	        // Update the event we fire to reflect what really happened after bounds took effect.
 	        uiData.x = _x;
 	        uiData.y = _y;
 	        uiData.deltaX = newState.x - _this.state.x;
 	        uiData.deltaY = newState.y - _this.state.y;
 	      }
-
+	
 	      // Short-circuit if user's callback killed it.
 	      var shouldUpdate = _this.props.onDrag(e, uiData);
 	      if (shouldUpdate === false) return false;
-
+	
 	      _this.setState(newState);
 	    };
-
+	
 	    _this.onDragStop = function (e, coreData) {
 	      if (!_this.state.dragging) return false;
-
+	
 	      // Short-circuit if user's callback killed it.
 	      var shouldStop = _this.props.onStop(e, (0, _positionFns.createDraggableData)(_this, coreData));
 	      if (shouldStop === false) return false;
-
+	
 	      (0, _log2.default)('Draggable: onDragStop: %j', coreData);
-
+	
 	      var newState /*: $Shape<DraggableState>*/ = {
 	        dragging: false,
 	        slackX: 0,
 	        slackY: 0
 	      };
-
+	
 	      // If this is a controlled component, the result of this operation will be to
 	      // revert back to the old position. We expect a handler on `onDragStop`, at the least.
 	      var controlled = Boolean(_this.props.position);
@@ -228,34 +226,34 @@ return /******/ (function(modules) { // webpackBootstrap
 	        var _this$props$position = _this.props.position;
 	        var _x2 = _this$props$position.x;
 	        var _y2 = _this$props$position.y;
-
+	
 	        newState.x = _x2;
 	        newState.y = _y2;
 	      }
-
+	
 	      _this.setState(newState);
 	    };
-
+	
 	    _this.state = {
 	      // Whether or not we are currently dragging.
 	      dragging: false,
-
+	
 	      // Whether or not we have been dragged before.
 	      dragged: false,
-
+	
 	      // Current transform x and y.
 	      x: props.position ? props.position.x : props.defaultPosition.x,
 	      y: props.position ? props.position.y : props.defaultPosition.y,
-
+	
 	      // Used for compensating for out-of-bounds drags
 	      slackX: 0, slackY: 0,
-
+	
 	      // Can only determine if SVG after mounting
 	      isElementSVG: false
 	    };
 	    return _this;
 	  }
-
+	
 	  _createClass(Draggable, [{
 	    key: 'componentWillMount',
 	    value: function componentWillMount() {
@@ -268,7 +266,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	    key: 'componentDidMount',
 	    value: function componentDidMount() {
 	      // Check to see if the element passed is an instanceof SVGElement
-	      if (typeof _global2.default.SVGElement !== 'undefined' && _reactDom2.default.findDOMNode(this) instanceof _global2.default.SVGElement) {
+	      if (typeof global.SVGElement !== 'undefined' && _reactDom2.default.findDOMNode(this) instanceof global.SVGElement) {
 	        this.setState({ isElementSVG: true });
 	      }
 	    }
@@ -289,23 +287,23 @@ return /******/ (function(modules) { // webpackBootstrap
 	    key: 'render',
 	    value: function render() {
 	      var _classNames;
-
+	
 	      var style = {},
 	          svgTransform = null;
-
+	
 	      // If this is controlled, we don't want to move it - unless it's dragging.
 	      var controlled = Boolean(this.props.position);
 	      var draggable = !controlled || this.state.dragging;
-
+	
 	      var position = this.props.position || this.props.defaultPosition;
 	      var transformOpts = {
 	        // Set left if horizontal drag is enabled
 	        x: (0, _positionFns.canDragX)(this) && draggable ? this.state.x : position.x,
-
+	
 	        // Set top if vertical drag is enabled
 	        y: (0, _positionFns.canDragY)(this) && draggable ? this.state.y : position.y
 	      };
-
+	
 	      // If this element was SVG, we use the `transform` attribute.
 	      if (this.state.isElementSVG) {
 	        svgTransform = (0, _domFns.createSVGTransform)(transformOpts);
@@ -316,16 +314,16 @@ return /******/ (function(modules) { // webpackBootstrap
 	        // has a clean slate.
 	        style = (0, _domFns.createCSSTransform)(transformOpts);
 	      }
-
+	
 	      var _props = this.props;
 	      var defaultClassName = _props.defaultClassName;
 	      var defaultClassNameDragging = _props.defaultClassNameDragging;
 	      var defaultClassNameDragged = _props.defaultClassNameDragged;
-
+	
 	      // Mark with class while dragging
-
+	
 	      var className = (0, _classnames2.default)(this.props.children.props.className || '', defaultClassName, (_classNames = {}, _defineProperty(_classNames, defaultClassNameDragging, this.state.dragging), _defineProperty(_classNames, defaultClassNameDragged, this.state.dragged), _classNames));
-
+	
 	      // Reuse the child provided
 	      // This makes it flexible to use whatever element is wanted (div, ul, etc)
 	      return _react2.default.createElement(
@@ -339,13 +337,13 @@ return /******/ (function(modules) { // webpackBootstrap
 	      );
 	    }
 	  }]);
-
+	
 	  return Draggable;
 	}(_react2.default.Component);
-
+	
 	Draggable.displayName = 'Draggable';
 	Draggable.propTypes = _extends({}, _DraggableCore2.default.propTypes, {
-
+	
 	  /**
 	   * `axis` determines which axis the draggable can move.
 	   *
@@ -360,7 +358,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	   * Defaults to 'both'.
 	   */
 	  axis: _react.PropTypes.oneOf(['both', 'x', 'y', 'none']),
-
+	
 	  /**
 	   * `bounds` determines the range of movement available to the element.
 	   * Available values are:
@@ -393,11 +391,11 @@ return /******/ (function(modules) { // webpackBootstrap
 	    top: _react.PropTypes.number,
 	    bottom: _react.PropTypes.number
 	  }), _react.PropTypes.string, _react.PropTypes.oneOf([false])]),
-
+	
 	  defaultClassName: _react.PropTypes.string,
 	  defaultClassNameDragging: _react.PropTypes.string,
 	  defaultClassNameDragged: _react.PropTypes.string,
-
+	
 	  /**
 	   * `defaultPosition` specifies the x and y that the dragged item should start at
 	   *
@@ -419,7 +417,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	    x: _react.PropTypes.number,
 	    y: _react.PropTypes.number
 	  }),
-
+	
 	  /**
 	   * `position`, if present, defines the current position of the element.
 	   *
@@ -444,7 +442,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	    x: _react.PropTypes.number,
 	    y: _react.PropTypes.number
 	  }),
-
+	
 	  /**
 	   * These properties should be defined on the child, not here.
 	   */
@@ -462,6 +460,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	  position: null
 	});
 	exports.default = Draggable;
+	/* WEBPACK VAR INJECTION */}.call(exports, (function() { return this; }())))
 
 /***/ },
 /* 2 */
@@ -485,21 +484,21 @@ return /******/ (function(modules) { // webpackBootstrap
 	  http://jedwatson.github.io/classnames
 	*/
 	/* global define */
-
+	
 	(function () {
 		'use strict';
-
+	
 		var hasOwn = {}.hasOwnProperty;
-
+	
 		function classNames () {
 			var classes = [];
-
+	
 			for (var i = 0; i < arguments.length; i++) {
 				var arg = arguments[i];
 				if (!arg) continue;
-
+	
 				var argType = typeof arg;
-
+	
 				if (argType === 'string' || argType === 'number') {
 					classes.push(arg);
 				} else if (Array.isArray(arg)) {
@@ -512,10 +511,10 @@ return /******/ (function(modules) { // webpackBootstrap
 					}
 				}
 			}
-
+	
 			return classes.join(' ');
 		}
-
+	
 		if (typeof module !== 'undefined' && module.exports) {
 			module.exports = classNames;
 		} else if (true) {
@@ -534,13 +533,13 @@ return /******/ (function(modules) { // webpackBootstrap
 /***/ function(module, exports, __webpack_require__) {
 
 	'use strict';
-
+	
 	Object.defineProperty(exports, "__esModule", {
 	  value: true
 	});
-
+	
 	var _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; };
-
+	
 	exports.matchesSelector = matchesSelector;
 	exports.matchesSelectorAndParentsTo = matchesSelectorAndParentsTo;
 	exports.addEvent = addEvent;
@@ -557,20 +556,20 @@ return /******/ (function(modules) { // webpackBootstrap
 	exports.addUserSelectStyles = addUserSelectStyles;
 	exports.removeUserSelectStyles = removeUserSelectStyles;
 	exports.styleHacks = styleHacks;
-
+	
 	var _shims = __webpack_require__(6);
-
+	
 	var _getPrefix = __webpack_require__(7);
-
+	
 	var _getPrefix2 = _interopRequireDefault(_getPrefix);
-
+	
 	function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
-
+	
 	function _defineProperty(obj, key, value) { if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
-
+	
 	/*:: import type {ControlPosition} from './types';*/
-
-
+	
+	
 	var matchesSelectorFunc = '';
 	function matchesSelector(el /*: Node*/, selector /*: string*/) /*: boolean*/ {
 	  if (!matchesSelectorFunc) {
@@ -579,11 +578,11 @@ return /******/ (function(modules) { // webpackBootstrap
 	      return (0, _shims.isFunction)(el[method]);
 	    });
 	  }
-
+	
 	  // $FlowIgnore: Doesn't think elements are indexable
 	  return el[matchesSelectorFunc].call(el, selector);
 	}
-
+	
 	// Works up the tree to the draggable itself attempting to match selector.
 	function matchesSelectorAndParentsTo(el /*: Node*/, selector /*: string*/, baseNode /*: Node*/) /*: boolean*/ {
 	  var node = el;
@@ -592,10 +591,10 @@ return /******/ (function(modules) { // webpackBootstrap
 	    if (node === baseNode) return false;
 	    node = node.parentNode;
 	  } while (node);
-
+	
 	  return false;
 	}
-
+	
 	function addEvent(el /*: ?Node*/, event /*: string*/, handler /*: Function*/) /*: void*/ {
 	  if (!el) {
 	    return;
@@ -609,7 +608,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	    el['on' + event] = handler;
 	  }
 	}
-
+	
 	function removeEvent(el /*: ?Node*/, event /*: string*/, handler /*: Function*/) /*: void*/ {
 	  if (!el) {
 	    return;
@@ -623,7 +622,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	    el['on' + event] = null;
 	  }
 	}
-
+	
 	function outerHeight(node /*: HTMLElement*/) /*: number*/ {
 	  // This is deliberately excluding margin for our calculations, since we are using
 	  // offsetTop which is including margin. See getBoundPosition
@@ -633,7 +632,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	  height += (0, _shims.int)(computedStyle.borderBottomWidth);
 	  return height;
 	}
-
+	
 	function outerWidth(node /*: HTMLElement*/) /*: number*/ {
 	  // This is deliberately excluding margin for our calculations, since we are using
 	  // offsetLeft which is including margin. See getBoundPosition
@@ -650,7 +649,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	  height -= (0, _shims.int)(computedStyle.paddingBottom);
 	  return height;
 	}
-
+	
 	function innerWidth(node /*: HTMLElement*/) /*: number*/ {
 	  var width = node.clientWidth;
 	  var computedStyle = node.ownerDocument.defaultView.getComputedStyle(node);
@@ -658,33 +657,33 @@ return /******/ (function(modules) { // webpackBootstrap
 	  width -= (0, _shims.int)(computedStyle.paddingRight);
 	  return width;
 	}
-
+	
 	// Get from offsetParent
 	function offsetXYFromParent(evt /*: {clientX: number, clientY: number}*/, offsetParent /*: HTMLElement*/) /*: ControlPosition*/ {
 	  var isBody = offsetParent === offsetParent.ownerDocument.body;
 	  var offsetParentRect = isBody ? { left: 0, top: 0 } : offsetParent.getBoundingClientRect();
-
+	
 	  var x = evt.clientX + offsetParent.scrollLeft - offsetParentRect.left;
 	  var y = evt.clientY + offsetParent.scrollTop - offsetParentRect.top;
-
+	
 	  return { x: x, y: y };
 	}
-
+	
 	function createCSSTransform(_ref) /*: Object*/ {
 	  var x = _ref.x;
 	  var y = _ref.y;
-
+	
 	  // Replace unitless items with px
 	  return _defineProperty({}, (0, _getPrefix.browserPrefixToKey)('transform', _getPrefix2.default), 'translate(' + x + 'px,' + y + 'px)');
 	}
-
+	
 	function createSVGTransform(_ref3) /*: string*/ {
 	  var x = _ref3.x;
 	  var y = _ref3.y;
-
+	
 	  return 'translate(' + x + ',' + y + ')';
 	}
-
+	
 	function getTouch(e /*: MouseEvent*/, identifier /*: number*/) /*: ?{clientX: number, clientY: number}*/ {
 	  return e.targetTouches && (0, _shims.findInArray)(e.targetTouches, function (t) {
 	    return identifier === t.identifier;
@@ -692,33 +691,33 @@ return /******/ (function(modules) { // webpackBootstrap
 	    return identifier === t.identifier;
 	  });
 	}
-
+	
 	function getTouchIdentifier(e /*: MouseEvent*/) /*: ?number*/ {
 	  if (e.targetTouches && e.targetTouches[0]) return e.targetTouches[0].identifier;
 	  if (e.changedTouches && e.changedTouches[0]) return e.changedTouches[0].identifier;
 	}
-
+	
 	// User-select Hacks:
 	//
 	// Useful for preventing blue highlights all over everything when dragging.
 	var userSelectPrefix = (0, _getPrefix.getPrefix)('user-select');
 	var userSelect = (0, _getPrefix.browserPrefixToStyle)('user-select', userSelectPrefix);
 	var userSelectStyle = ';' + userSelect + ': none;';
-
+	
 	// Note we're passing `document` b/c we could be iframed
 	function addUserSelectStyles(body /*: HTMLElement*/) {
 	  var style = body.getAttribute('style') || '';
 	  body.setAttribute('style', style + userSelectStyle);
 	}
-
+	
 	function removeUserSelectStyles(body /*: HTMLElement*/) {
 	  var style = body.getAttribute('style') || '';
 	  body.setAttribute('style', style.replace(userSelectStyle, ''));
 	}
-
+	
 	function styleHacks() /*: Object*/ {
 	  var childStyle /*: Object*/ = arguments.length <= 0 || arguments[0] === undefined ? {} : arguments[0];
-
+	
 	  // Workaround IE pointer events; see #51
 	  // https://github.com/mzabriskie/react-draggable/issues/51#issuecomment-103488278
 	  return _extends({
@@ -731,7 +730,7 @@ return /******/ (function(modules) { // webpackBootstrap
 /***/ function(module, exports) {
 
 	'use strict';
-
+	
 	Object.defineProperty(exports, "__esModule", {
 	  value: true
 	});
@@ -740,26 +739,26 @@ return /******/ (function(modules) { // webpackBootstrap
 	exports.isNum = isNum;
 	exports.int = int;
 	exports.dontSetMe = dontSetMe;
-
+	
 	// @credits https://gist.github.com/rogozhnikoff/a43cfed27c41e4e68cdc
 	function findInArray(array /*: Array<any>*/, callback /*: Function*/) /*: any*/ {
 	  for (var i = 0, length = array.length; i < length; i++) {
 	    if (callback.apply(callback, [array[i], i, array])) return array[i];
 	  }
 	}
-
+	
 	function isFunction(func /*: any*/) /*: boolean*/ {
 	  return typeof func === 'function' || Object.prototype.toString.call(func) === '[object Function]';
 	}
-
+	
 	function isNum(num /*: any*/) /*: boolean*/ {
 	  return typeof num === 'number' && !isNaN(num);
 	}
-
+	
 	function int(a /*: string*/) /*: number*/ {
 	  return parseInt(a, 10);
 	}
-
+	
 	function dontSetMe(props /*: Object*/, propName /*: string*/, componentName /*: string*/) {
 	  if (props[propName]) {
 	    return new Error('Invalid prop ' + propName + ' passed to ' + componentName + ' - do not set this, set it on the child.');
@@ -771,41 +770,42 @@ return /******/ (function(modules) { // webpackBootstrap
 /***/ function(module, exports) {
 
 	'use strict';
-
+	
 	Object.defineProperty(exports, "__esModule", {
 	  value: true
 	});
 	exports.getPrefix = getPrefix;
 	exports.browserPrefixToKey = browserPrefixToKey;
 	exports.browserPrefixToStyle = browserPrefixToStyle;
+	
 	var prefixes = ['Moz', 'Webkit', 'O', 'ms'];
 	function getPrefix() /*: string*/ {
 	  var prop /*: string*/ = arguments.length <= 0 || arguments[0] === undefined ? 'transform' : arguments[0];
-
+	
 	  // Checking specifically for 'window.document' is for pseudo-browser server-side
 	  // environments that define 'window' as the global context.
 	  // E.g. React-rails (see https://github.com/reactjs/react-rails/pull/84)
 	  if (typeof window === 'undefined' || typeof window.document === 'undefined') return '';
-
+	
 	  var style = window.document.documentElement.style;
-
+	
 	  if (prop in style) return '';
-
+	
 	  for (var i = 0; i < prefixes.length; i++) {
 	    if (browserPrefixToKey(prop, prefixes[i]) in style) return prefixes[i];
 	  }
-
+	
 	  return '';
 	}
-
+	
 	function browserPrefixToKey(prop /*: string*/, prefix /*: string*/) /*: string*/ {
 	  return prefix ? '' + prefix + kebabToTitleCase(prop) : prop;
 	}
-
+	
 	function browserPrefixToStyle(prop /*: string*/, prefix /*: string*/) /*: string*/ {
 	  return prefix ? '-' + prefix.toLowerCase() + '-' + prop : prop;
 	}
-
+	
 	function kebabToTitleCase(str /*: string*/) /*: string*/ {
 	  var out = '';
 	  var shouldCapitalize = true;
@@ -821,7 +821,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	  }
 	  return out;
 	}
-
+	
 	// Default export is the prefix itself, like 'Moz', 'Webkit', etc
 	// Note that you may have to re-test for certain things; for instance, Chrome 50
 	// can handle unprefixed `transform`, but not unprefixed `user-select`
@@ -832,7 +832,7 @@ return /******/ (function(modules) { // webpackBootstrap
 /***/ function(module, exports, __webpack_require__) {
 
 	'use strict';
-
+	
 	Object.defineProperty(exports, "__esModule", {
 	  value: true
 	});
@@ -843,33 +843,33 @@ return /******/ (function(modules) { // webpackBootstrap
 	exports.getControlPosition = getControlPosition;
 	exports.createCoreData = createCoreData;
 	exports.createDraggableData = createDraggableData;
-
+	
 	var _shims = __webpack_require__(6);
-
+	
 	var _reactDom = __webpack_require__(3);
-
+	
 	var _reactDom2 = _interopRequireDefault(_reactDom);
-
+	
 	var _domFns = __webpack_require__(5);
-
+	
 	function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
-
+	
 	/*:: import type Draggable from '../Draggable';*/
 	/*:: import type {Bounds, ControlPosition, DraggableData} from './types';*/
 	/*:: import type DraggableCore from '../DraggableCore';*/
 	function getBoundPosition(draggable /*: Draggable*/, x /*: number*/, y /*: number*/) /*: [number, number]*/ {
 	  // If no bounds, short-circuit and move on
 	  if (!draggable.props.bounds) return [x, y];
-
+	
 	  // Clone new bounds
 	  var bounds = draggable.props.bounds;
-
+	
 	  bounds = typeof bounds === 'string' ? bounds : cloneBounds(bounds);
 	  var node = _reactDom2.default.findDOMNode(draggable);
-
+	
 	  if (typeof bounds === 'string') {
 	    var ownerDocument = node.ownerDocument;
-
+	
 	    var ownerWindow = ownerDocument.defaultView;
 	    var boundNode = void 0;
 	    if (bounds === 'parent') {
@@ -888,32 +888,32 @@ return /******/ (function(modules) { // webpackBootstrap
 	      bottom: (0, _domFns.innerHeight)(boundNode) - (0, _domFns.outerHeight)(node) - node.offsetTop
 	    };
 	  }
-
+	
 	  // Keep x and y below right and bottom limits...
 	  if ((0, _shims.isNum)(bounds.right)) x = Math.min(x, bounds.right);
 	  if ((0, _shims.isNum)(bounds.bottom)) y = Math.min(y, bounds.bottom);
-
+	
 	  // But above left and top limits.
 	  if ((0, _shims.isNum)(bounds.left)) x = Math.max(x, bounds.left);
 	  if ((0, _shims.isNum)(bounds.top)) y = Math.max(y, bounds.top);
-
+	
 	  return [x, y];
 	}
-
+	
 	function snapToGrid(grid /*: [number, number]*/, pendingX /*: number*/, pendingY /*: number*/) /*: [number, number]*/ {
 	  var x = Math.round(pendingX / grid[0]) * grid[0];
 	  var y = Math.round(pendingY / grid[1]) * grid[1];
 	  return [x, y];
 	}
-
+	
 	function canDragX(draggable /*: Draggable*/) /*: boolean*/ {
 	  return draggable.props.axis === 'both' || draggable.props.axis === 'x';
 	}
-
+	
 	function canDragY(draggable /*: Draggable*/) /*: boolean*/ {
 	  return draggable.props.axis === 'both' || draggable.props.axis === 'y';
 	}
-
+	
 	// Get {x, y} positions from event.
 	function getControlPosition(e /*: MouseEvent*/, touchIdentifier /*: ?number*/, draggableCore /*: DraggableCore*/) /*: ?ControlPosition*/ {
 	  var touchObj = typeof touchIdentifier === 'number' ? (0, _domFns.getTouch)(e, touchIdentifier) : null;
@@ -923,13 +923,13 @@ return /******/ (function(modules) { // webpackBootstrap
 	  var offsetParent = draggableCore.props.offsetParent || node.offsetParent || node.ownerDocument.body;
 	  return (0, _domFns.offsetXYFromParent)(touchObj || e, offsetParent);
 	}
-
+	
 	// Create an data object exposed by <DraggableCore>'s events
 	function createCoreData(draggable /*: DraggableCore*/, x /*: number*/, y /*: number*/) /*: DraggableData*/ {
 	  // State changes are often (but not always!) async. We want the latest value.
 	  var state = draggable._pendingState || draggable.state;
 	  var isStart = !(0, _shims.isNum)(state.lastX);
-
+	
 	  if (isStart) {
 	    // If this is our first move, use the x and y as last coords.
 	    return {
@@ -948,7 +948,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	    };
 	  }
 	}
-
+	
 	// Create an data exposed by <Draggable>'s events
 	function createDraggableData(draggable /*: Draggable*/, coreData /*: DraggableData*/) /*: DraggableData*/ {
 	  return {
@@ -961,7 +961,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	    lastY: draggable.state.y
 	  };
 	}
-
+	
 	// A lot faster than stringify/parse
 	function cloneBounds(bounds /*: Bounds*/) /*: Bounds*/ {
 	  return {
@@ -977,41 +977,41 @@ return /******/ (function(modules) { // webpackBootstrap
 /***/ function(module, exports, __webpack_require__) {
 
 	/* WEBPACK VAR INJECTION */(function(process) {'use strict';
-
+	
 	Object.defineProperty(exports, "__esModule", {
 	  value: true
 	});
-
+	
 	var _slicedToArray = function () { function sliceIterator(arr, i) { var _arr = []; var _n = true; var _d = false; var _e = undefined; try { for (var _i = arr[Symbol.iterator](), _s; !(_n = (_s = _i.next()).done); _n = true) { _arr.push(_s.value); if (i && _arr.length === i) break; } } catch (err) { _d = true; _e = err; } finally { try { if (!_n && _i["return"]) _i["return"](); } finally { if (_d) throw _e; } } return _arr; } return function (arr, i) { if (Array.isArray(arr)) { return arr; } else if (Symbol.iterator in Object(arr)) { return sliceIterator(arr, i); } else { throw new TypeError("Invalid attempt to destructure non-iterable instance"); } }; }();
-
+	
 	var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
-
+	
 	var _react = __webpack_require__(2);
-
+	
 	var _react2 = _interopRequireDefault(_react);
-
+	
 	var _reactDom = __webpack_require__(3);
-
+	
 	var _reactDom2 = _interopRequireDefault(_reactDom);
-
+	
 	var _domFns = __webpack_require__(5);
-
+	
 	var _positionFns = __webpack_require__(8);
-
+	
 	var _shims = __webpack_require__(6);
-
+	
 	var _log = __webpack_require__(11);
-
+	
 	var _log2 = _interopRequireDefault(_log);
-
+	
 	function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
-
+	
 	function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
-
+	
 	function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return call && (typeof call === "object" || typeof call === "function") ? call : self; }
-
+	
 	function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
-
+	
 	// Simple abstraction for dragging events names.
 	/*:: import type {EventHandler} from './utils/types';*/
 	var eventsFor = {
@@ -1026,38 +1026,38 @@ return /******/ (function(modules) { // webpackBootstrap
 	    stop: 'mouseup'
 	  }
 	};
-
+	
 	// Default to mouse events.
 	var dragEventFor = eventsFor.mouse;
-
+	
 	//
 	// Define <DraggableCore>.
 	//
 	// <DraggableCore> is for advanced usage of <Draggable>. It maintains minimal internal state so it can
 	// work well with libraries that require more control over the element.
 	//
-
+	
 	/*:: type CoreState = {
 	  dragging: boolean,
 	  lastX: number,
 	  lastY: number,
 	  touchIdentifier: ?number
 	};*/
-
+	
 	var DraggableCore = function (_React$Component) {
 	  _inherits(DraggableCore, _React$Component);
-
+	
 	  function DraggableCore() {
 	    var _Object$getPrototypeO;
-
+	
 	    var _temp, _this, _ret;
-
+	
 	    _classCallCheck(this, DraggableCore);
-
+	
 	    for (var _len = arguments.length, args = Array(_len), _key = 0; _key < _len; _key++) {
 	      args[_key] = arguments[_key];
 	    }
-
+	
 	    return _ret = (_temp = (_this = _possibleConstructorReturn(this, (_Object$getPrototypeO = Object.getPrototypeOf(DraggableCore)).call.apply(_Object$getPrototypeO, [this].concat(args))), _this), _this.state = {
 	      dragging: false,
 	      // Used while dragging to determine deltas.
@@ -1066,93 +1066,93 @@ return /******/ (function(modules) { // webpackBootstrap
 	    }, _this.handleDragStart = function (e) {
 	      // Make it possible to attach event handlers on top of this one.
 	      _this.props.onMouseDown(e);
-
+	
 	      // Only accept left-clicks.
 	      if (!_this.props.allowAnyClick && typeof e.button === 'number' && e.button !== 0) return false;
-
+	
 	      // Get nodes. Be sure to grab relative document (could be iframed)
 	      var domNode = _reactDom2.default.findDOMNode(_this);
 	      var ownerDocument = domNode.ownerDocument;
-
+	
 	      // Short circuit if handle or cancel prop was provided and selector doesn't match.
-
+	
 	      if (_this.props.disabled || !(e.target instanceof ownerDocument.defaultView.Node) || _this.props.handle && !(0, _domFns.matchesSelectorAndParentsTo)(e.target, _this.props.handle, domNode) || _this.props.cancel && (0, _domFns.matchesSelectorAndParentsTo)(e.target, _this.props.cancel, domNode)) {
 	        return;
 	      }
-
+	
 	      // Set touch identifier in component state if this is a touch event. This allows us to
 	      // distinguish between individual touches on multitouch screens by identifying which
 	      // touchpoint was set to this element.
 	      var touchIdentifier = (0, _domFns.getTouchIdentifier)(e);
 	      _this.setState({ touchIdentifier: touchIdentifier });
-
+	
 	      // Get the current drag point from the event. This is used as the offset.
 	      var position = (0, _positionFns.getControlPosition)(e, touchIdentifier, _this);
 	      if (position == null) return; // not possible but satisfies flow
 	      var x = position.x;
 	      var y = position.y;
-
+	
 	      // Create an event object with all the data parents need to make a decision here.
-
+	
 	      var coreEvent = (0, _positionFns.createCoreData)(_this, x, y);
-
+	
 	      (0, _log2.default)('DraggableCore: handleDragStart: %j', coreEvent);
-
+	
 	      // Call event handler. If it returns explicit false, cancel.
 	      (0, _log2.default)('calling', _this.props.onStart);
 	      var shouldUpdate = _this.props.onStart(e, coreEvent);
 	      if (shouldUpdate === false) return;
-
+	
 	      // Add a style to the body to disable user-select. This prevents text from
 	      // being selected all over the page.
 	      if (_this.props.enableUserSelectHack) (0, _domFns.addUserSelectStyles)(ownerDocument.body);
-
+	
 	      // Initiate dragging. Set the current x and y as offsets
 	      // so we know how much we've moved during the drag. This allows us
 	      // to drag elements around even if they have been moved, without issue.
 	      _this.setState({
 	        dragging: true,
-
+	
 	        lastX: x,
 	        lastY: y
 	      });
-
+	
 	      // Add events to the document directly so we catch when the user's mouse/touch moves outside of
 	      // this element. We use different events depending on whether or not we have detected that this
 	      // is a touch-capable device.
 	      (0, _domFns.addEvent)(ownerDocument, dragEventFor.move, _this.handleDrag);
 	      (0, _domFns.addEvent)(ownerDocument, dragEventFor.stop, _this.handleDragStop);
 	    }, _this.handleDrag = function (e) {
-
+	
 	      // Get the current drag point from the event. This is used as the offset.
 	      var position = (0, _positionFns.getControlPosition)(e, _this.state.touchIdentifier, _this);
 	      if (position == null) return;
 	      var x = position.x;
 	      var y = position.y;
-
+	
 	      // Snap to grid if prop has been provided
-
+	
 	      if (x !== x) debugger;
-
+	
 	      if (Array.isArray(_this.props.grid)) {
 	        var deltaX = x - _this.state.lastX,
 	            deltaY = y - _this.state.lastY;
-
+	
 	        var _snapToGrid = (0, _positionFns.snapToGrid)(_this.props.grid, deltaX, deltaY);
-
+	
 	        var _snapToGrid2 = _slicedToArray(_snapToGrid, 2);
-
+	
 	        deltaX = _snapToGrid2[0];
 	        deltaY = _snapToGrid2[1];
-
+	
 	        if (!deltaX && !deltaY) return; // skip useless drag
 	        x = _this.state.lastX + deltaX, y = _this.state.lastY + deltaY;
 	      }
-
+	
 	      var coreEvent = (0, _positionFns.createCoreData)(_this, x, y);
-
+	
 	      (0, _log2.default)('DraggableCore: handleDrag: %j', coreEvent);
-
+	
 	      // Call event handler. If it returns explicit false, trigger end.
 	      var shouldUpdate = _this.props.onDrag(e, coreEvent);
 	      if (shouldUpdate === false) {
@@ -1168,84 +1168,85 @@ return /******/ (function(modules) { // webpackBootstrap
 	        }
 	        return;
 	      }
-
+	
 	      _this.setState({
 	        lastX: x,
 	        lastY: y
 	      });
 	    }, _this.handleDragStop = function (e) {
 	      if (!_this.state.dragging) return;
-
+	
 	      var position = (0, _positionFns.getControlPosition)(e, _this.state.touchIdentifier, _this);
 	      if (position == null) return;
 	      var x = position.x;
 	      var y = position.y;
-
+	
 	      var coreEvent = (0, _positionFns.createCoreData)(_this, x, y);
-
+	
 	      // Remove user-select hack
 	      if (_this.props.enableUserSelectHack) (0, _domFns.removeUserSelectStyles)(_reactDom2.default.findDOMNode(_this).ownerDocument.body);
-
+	
 	      (0, _log2.default)('DraggableCore: handleDragStop: %j', coreEvent);
-
+	
 	      // Reset the el.
 	      _this.setState({
 	        dragging: false,
 	        lastX: NaN,
 	        lastY: NaN
 	      });
-
+	
 	      // Call event handler
 	      _this.props.onStop(e, coreEvent);
-
+	
 	      // Remove event handlers
-
+	
 	      var _ReactDOM$findDOMNode = _reactDom2.default.findDOMNode(_this);
-
+	
 	      var ownerDocument = _ReactDOM$findDOMNode.ownerDocument;
-
+	
 	      (0, _log2.default)('DraggableCore: Removing handlers');
 	      (0, _domFns.removeEvent)(ownerDocument, dragEventFor.move, _this.handleDrag);
 	      (0, _domFns.removeEvent)(ownerDocument, dragEventFor.stop, _this.handleDragStop);
 	    }, _this.onMouseDown = function (e) {
 	      dragEventFor = eventsFor.mouse; // on touchscreen laptops we could switch back to mouse
-
+	
 	      return _this.handleDragStart(e);
 	    }, _this.onMouseUp = function (e) {
 	      dragEventFor = eventsFor.mouse;
-
+	
 	      return _this.handleDragStop(e);
 	    }, _this.onTouchStart = function (e) {
 	      // We're on a touch device now, so change the event handlers
 	      dragEventFor = eventsFor.touch;
-
+	
 	      return _this.handleDragStart(e);
 	    }, _this.onTouchEnd = function (e) {
 	      // We're on a touch device now, so change the event handlers
 	      dragEventFor = eventsFor.touch;
-
+	
 	      return _this.handleDragStop(e);
 	    }, _temp), _possibleConstructorReturn(_this, _ret);
 	  }
-
+	
 	  _createClass(DraggableCore, [{
 	    key: 'componentWillUnmount',
 	    value: function componentWillUnmount() {
 	      // Remove any leftover event handlers. Remove both touch and mouse handlers in case
 	      // some browser quirk caused a touch event to fire during a mouse move, or vice versa.
+	
 	      var _ReactDOM$findDOMNode2 = _reactDom2.default.findDOMNode(this);
-
+	
 	      var ownerDocument = _ReactDOM$findDOMNode2.ownerDocument;
-
+	
 	      (0, _domFns.removeEvent)(ownerDocument, eventsFor.mouse.move, this.handleDrag);
 	      (0, _domFns.removeEvent)(ownerDocument, eventsFor.touch.move, this.handleDrag);
 	      (0, _domFns.removeEvent)(ownerDocument, eventsFor.mouse.stop, this.handleDragStop);
 	      (0, _domFns.removeEvent)(ownerDocument, eventsFor.touch.stop, this.handleDragStop);
 	      if (this.props.enableUserSelectHack) (0, _domFns.removeUserSelectStyles)(ownerDocument.body);
 	    }
-
+	
 	    // Same as onMouseDown (start drag), but now consider this a touch device.
-
+	
 	  }, {
 	    key: 'render',
 	    value: function render() {
@@ -1253,7 +1254,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	      // This makes it flexible to use whatever element is wanted (div, ul, etc)
 	      return _react2.default.cloneElement(_react2.default.Children.only(this.props.children), {
 	        style: (0, _domFns.styleHacks)(this.props.children.props.style),
-
+	
 	        // Note: mouseMove handler is attached to document so it will still function
 	        // when the user drags quickly and leaves the bounds of the element.
 	        onMouseDown: this.onMouseDown,
@@ -1263,10 +1264,10 @@ return /******/ (function(modules) { // webpackBootstrap
 	      });
 	    }
 	  }]);
-
+	
 	  return DraggableCore;
 	}(_react2.default.Component);
-
+	
 	DraggableCore.displayName = 'DraggableCore';
 	DraggableCore.propTypes = {
 	  /**
@@ -1276,20 +1277,20 @@ return /******/ (function(modules) { // webpackBootstrap
 	   * Defaults to `false`.
 	   */
 	  allowAnyClick: _react.PropTypes.bool,
-
+	
 	  /**
 	   * `disabled`, if true, stops the <Draggable> from dragging. All handlers,
 	   * with the exception of `onMouseDown`, will not fire.
 	   */
 	  disabled: _react.PropTypes.bool,
-
+	
 	  /**
 	   * By default, we add 'user-select:none' attributes to the document body
 	   * to prevent ugly text selection during drag. If this is causing problems
 	   * for your app, set this to `false`.
 	   */
 	  enableUserSelectHack: _react.PropTypes.bool,
-
+	
 	  /**
 	   * `offsetParent`, if set, uses the passed DOM node to compute drag offsets
 	   * instead of using the parent node.
@@ -1299,12 +1300,12 @@ return /******/ (function(modules) { // webpackBootstrap
 	      throw new Error('Draggable\'s offsetParent must be a DOM Node.');
 	    }
 	  },
-
+	
 	  /**
 	   * `grid` specifies the x and y that dragging should snap to.
 	   */
 	  grid: _react.PropTypes.arrayOf(_react.PropTypes.number),
-
+	
 	  /**
 	   * `handle` specifies a selector to be used as the handle that initiates drag.
 	   *
@@ -1326,7 +1327,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	   * ```
 	   */
 	  handle: _react.PropTypes.string,
-
+	
 	  /**
 	   * `cancel` specifies a selector to be used to prevent drag initialization.
 	   *
@@ -1348,31 +1349,31 @@ return /******/ (function(modules) { // webpackBootstrap
 	   * ```
 	   */
 	  cancel: _react.PropTypes.string,
-
+	
 	  /**
 	   * Called when dragging starts.
 	   * If this function returns the boolean false, dragging will be canceled.
 	   */
 	  onStart: _react.PropTypes.func,
-
+	
 	  /**
 	   * Called while dragging.
 	   * If this function returns the boolean false, dragging will be canceled.
 	   */
 	  onDrag: _react.PropTypes.func,
-
+	
 	  /**
 	   * Called when dragging stops.
 	   * If this function returns the boolean false, the drag will remain active.
 	   */
 	  onStop: _react.PropTypes.func,
-
+	
 	  /**
 	   * A workaround option which can be passed if onMouseDown needs to be accessed,
 	   * since it'll always be blocked (as there is internal use of onMouseDown)
 	   */
 	  onMouseDown: _react.PropTypes.func,
-
+	
 	  /**
 	   * These properties should be defined on the child, not here.
 	   */
@@ -1402,79 +1403,38 @@ return /******/ (function(modules) { // webpackBootstrap
 /***/ function(module, exports) {
 
 	// shim for using process in browser
+	
 	var process = module.exports = {};
-
+	
 	// cached from whatever global is present so that test runners that stub it
 	// don't break things.  But we need to wrap it in a try catch in case it is
 	// wrapped in strict mode code which doesn't define any globals.  It's inside a
 	// function because try/catches deoptimize in certain engines.
-
+	
 	var cachedSetTimeout;
 	var cachedClearTimeout;
-
+	
 	(function () {
-	    try {
-	        cachedSetTimeout = setTimeout;
-	    } catch (e) {
-	        cachedSetTimeout = function () {
-	            throw new Error('setTimeout is not defined');
-	        }
+	  try {
+	    cachedSetTimeout = setTimeout;
+	  } catch (e) {
+	    cachedSetTimeout = function () {
+	      throw new Error('setTimeout is not defined');
 	    }
-	    try {
-	        cachedClearTimeout = clearTimeout;
-	    } catch (e) {
-	        cachedClearTimeout = function () {
-	            throw new Error('clearTimeout is not defined');
-	        }
+	  }
+	  try {
+	    cachedClearTimeout = clearTimeout;
+	  } catch (e) {
+	    cachedClearTimeout = function () {
+	      throw new Error('clearTimeout is not defined');
 	    }
+	  }
 	} ())
-	function runTimeout(fun) {
-	    if (cachedSetTimeout === setTimeout) {
-	        //normal enviroments in sane situations
-	        return setTimeout(fun, 0);
-	    }
-	    try {
-	        // when when somebody has screwed with setTimeout but no I.E. maddness
-	        return cachedSetTimeout(fun, 0);
-	    } catch(e){
-	        try {
-	            // When we are in I.E. but the script has been evaled so I.E. doesn't trust the global object when called normally
-	            return cachedSetTimeout.call(null, fun, 0);
-	        } catch(e){
-	            // same as above but when it's a version of I.E. that must have the global object for 'this', hopfully our context correct otherwise it will throw a global error
-	            return cachedSetTimeout.call(this, fun, 0);
-	        }
-	    }
-
-
-	}
-	function runClearTimeout(marker) {
-	    if (cachedClearTimeout === clearTimeout) {
-	        //normal enviroments in sane situations
-	        return clearTimeout(marker);
-	    }
-	    try {
-	        // when when somebody has screwed with setTimeout but no I.E. maddness
-	        return cachedClearTimeout(marker);
-	    } catch (e){
-	        try {
-	            // When we are in I.E. but the script has been evaled so I.E. doesn't  trust the global object when called normally
-	            return cachedClearTimeout.call(null, marker);
-	        } catch (e){
-	            // same as above but when it's a version of I.E. that must have the global object for 'this', hopfully our context correct otherwise it will throw a global error.
-	            // Some versions of I.E. have different rules for clearTimeout vs setTimeout
-	            return cachedClearTimeout.call(this, marker);
-	        }
-	    }
-
-
-
-	}
 	var queue = [];
 	var draining = false;
 	var currentQueue;
 	var queueIndex = -1;
-
+	
 	function cleanUpNextTick() {
 	    if (!draining || !currentQueue) {
 	        return;
@@ -1489,14 +1449,14 @@ return /******/ (function(modules) { // webpackBootstrap
 	        drainQueue();
 	    }
 	}
-
+	
 	function drainQueue() {
 	    if (draining) {
 	        return;
 	    }
-	    var timeout = runTimeout(cleanUpNextTick);
+	    var timeout = cachedSetTimeout(cleanUpNextTick);
 	    draining = true;
-
+	
 	    var len = queue.length;
 	    while(len) {
 	        currentQueue = queue;
@@ -1511,9 +1471,9 @@ return /******/ (function(modules) { // webpackBootstrap
 	    }
 	    currentQueue = null;
 	    draining = false;
-	    runClearTimeout(timeout);
+	    cachedClearTimeout(timeout);
 	}
-
+	
 	process.nextTick = function (fun) {
 	    var args = new Array(arguments.length - 1);
 	    if (arguments.length > 1) {
@@ -1523,10 +1483,10 @@ return /******/ (function(modules) { // webpackBootstrap
 	    }
 	    queue.push(new Item(fun, args));
 	    if (queue.length === 1 && !draining) {
-	        runTimeout(drainQueue);
+	        cachedSetTimeout(drainQueue, 0);
 	    }
 	};
-
+	
 	// v8 likes predictible objects
 	function Item(fun, array) {
 	    this.fun = fun;
@@ -1541,9 +1501,9 @@ return /******/ (function(modules) { // webpackBootstrap
 	process.argv = [];
 	process.version = ''; // empty string to avoid regexp issues
 	process.versions = {};
-
+	
 	function noop() {}
-
+	
 	process.on = noop;
 	process.addListener = noop;
 	process.once = noop;
@@ -1551,11 +1511,11 @@ return /******/ (function(modules) { // webpackBootstrap
 	process.removeListener = noop;
 	process.removeAllListeners = noop;
 	process.emit = noop;
-
+	
 	process.binding = function (name) {
 	    throw new Error('process.binding is not supported');
 	};
-
+	
 	process.cwd = function () { return '/' };
 	process.chdir = function (dir) {
 	    throw new Error('process.chdir is not supported');
@@ -1568,36 +1528,21 @@ return /******/ (function(modules) { // webpackBootstrap
 /***/ function(module, exports, __webpack_require__) {
 
 	"use strict";
-
+	
 	Object.defineProperty(exports, "__esModule", {
 	  value: true
 	});
 	exports.default = log;
-
+	
 	/*eslint no-console:0*/
 	function log() {
 	  var _console;
-
+	
 	  if ((undefined)) (_console = console).log.apply(_console, arguments);
 	}
-
-/***/ },
-/* 12 */
-/***/ function(module, exports) {
-
-	/* WEBPACK VAR INJECTION */(function(global) {if (typeof window !== "undefined") {
-	    module.exports = window;
-	} else if (typeof global !== "undefined") {
-	    module.exports = global;
-	} else if (typeof self !== "undefined"){
-	    module.exports = self;
-	} else {
-	    module.exports = {};
-	}
-
-	/* WEBPACK VAR INJECTION */}.call(exports, (function() { return this; }())))
 
 /***/ }
 /******/ ])
 });
 ;
+//# sourceMappingURL=react-draggable.js.map

--- a/lib/Draggable.es6
+++ b/lib/Draggable.es6
@@ -8,6 +8,7 @@ import {canDragX, canDragY, createDraggableData, getBoundPosition} from './utils
 import {dontSetMe} from './utils/shims';
 import DraggableCore from './DraggableCore';
 import log from './utils/log';
+import global from 'global';
 import type {DraggableEventHandler} from './utils/types';
 
 type DraggableState = {

--- a/lib/Draggable.es6
+++ b/lib/Draggable.es6
@@ -8,7 +8,6 @@ import {canDragX, canDragY, createDraggableData, getBoundPosition} from './utils
 import {dontSetMe} from './utils/shims';
 import DraggableCore from './DraggableCore';
 import log from './utils/log';
-import global from 'global';
 import type {DraggableEventHandler} from './utils/types';
 
 type DraggableState = {
@@ -193,7 +192,7 @@ export default class Draggable extends React.Component {
 
   componentDidMount() {
     // Check to see if the element passed is an instanceof SVGElement
-    if(typeof global.SVGElement !== 'undefined' && ReactDOM.findDOMNode(this) instanceof global.SVGElement) {
+    if(typeof SVGElement !== 'undefined' && ReactDOM.findDOMNode(this) instanceof SVGElement) {
       this.setState({ isElementSVG: true });
     }
   }

--- a/package.json
+++ b/package.json
@@ -67,7 +67,6 @@
     "test"
   ],
   "dependencies": {
-    "classnames": "^2.2.5",
-    "global": "^4.3.0"
+    "classnames": "^2.2.5"
   }
 }

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "test"
   ],
   "dependencies": {
-    "classnames": "^2.2.5"
+    "classnames": "^2.2.5",
+    "global": "^4.3.0"
   }
 }


### PR DESCRIPTION
Tested that this change fixes the issue https://github.com/mzabriskie/react-draggable/issues/162 "Uncaught TypeError: Cannot read property 'SVGElement' of undefined"

Original changes were made by tkrkt in https://github.com/tkrkt/react-draggable/commit/41ec001671dec5c1afebecb5a8e984a13010f6a4 in a fork of react-draggable

Alternative approach is to avoid using global and assume that SVGElement can be defined as a global, instead of:

``` javascript
    if(typeof global.SVGElement !== 'undefined' && ReactDOM.findDOMNode(this) instanceof global.SVGElement) {
    ...
```

we can use

``` javascript
    if(typeof SVGElement !== 'undefined' && ReactDOM.findDOMNode(this) instanceof SVGElement) {
    ...
```

Please, note that after running webpack in Windows at the root the dist file has been changed somewhat, looks like line-endings were changed and not sure if source map has been properly generated, might be that we may need to run webpack to generate the dist in a Linux or Mac environment.
