### PR TITLE
Get ownerDocument before calling onStop handlers

### DIFF
--- a/lib/DraggableCore.es6
+++ b/lib/DraggableCore.es6
@@ -301,9 +301,10 @@ export default class DraggableCore extends React.Component {
     if (position == null) return;
     const {x, y} = position;
     const coreEvent = createCoreData(this, x, y);
+    const {ownerDocument} = ReactDOM.findDOMNode(this);
 
     // Remove user-select hack
-    if (this.props.enableUserSelectHack) removeUserSelectStyles(ReactDOM.findDOMNode(this).ownerDocument.body);
+    if (this.props.enableUserSelectHack) removeUserSelectStyles(ownerDocument.body);
 
     log('DraggableCore: handleDragStop: %j', coreEvent);
 
@@ -318,7 +319,6 @@ export default class DraggableCore extends React.Component {
     this.props.onStop(e, coreEvent);
 
     // Remove event handlers
-    const {ownerDocument} = ReactDOM.findDOMNode(this);
     log('DraggableCore: Removing handlers');
     removeEvent(ownerDocument, dragEventFor.move, this.handleDrag);
     removeEvent(ownerDocument, dragEventFor.stop, this.handleDragStop);


### PR DESCRIPTION
If a draggable `onStop` handler (invoked in [DraggableCore:318](https://github.com/mzabriskie/react-draggable/blob/master/lib/DraggableCore.es6#L318)) causes the wrapped component to unmount, calling `ReactDOM.findDOMNode` in [line 321](https://github.com/mzabriskie/react-draggable/blob/master/lib/DraggableCore.es6#L321) will error with `Uncaught Invariant Violation: findDOMNode was called on an unmounted component`.

Using findDOMNode before calling `onStop` avoids that bug and prevents having to also invoke it for the userSelect hack. A win-win.
