### PR TITLE
Add ability to pass in scale prop to correctly move draggable element at different scales

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,13 +217,15 @@ onStop: DraggableEventHandler,
 // becomes 'controlled' and is not responsive to user input. Use `position`
 // if you need to have direct control of the element.
 position: {x: number, y: number},
-}
 
 // Specifies the scale of the canvas you are dragging this element on. This allows
 // you to, for example, get the correct drag deltas while you are zoomed in or out via
 // a transform or matrix in the parent of this element. Also, useful for correct drag 
 // deltas if the parent element is scaled through css transform 
 scale: number
+
+}
+
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -216,8 +216,14 @@ onStop: DraggableEventHandler,
 // Much like React form elements, if this property is present, the item
 // becomes 'controlled' and is not responsive to user input. Use `position`
 // if you need to have direct control of the element.
-position: {x: number, y: number}
+position: {x: number, y: number},
 }
+
+// Specifies the scale of the canvas you are dragging this element on. This allows
+// you to, for example, get the correct drag deltas while you are zoomed in or out via
+// a transform or matrix in the parent of this element. Also, useful for correct drag 
+// deltas if the parent element is scaled through css transform 
+scale: number
 ```
 
 

--- a/example/example.js
+++ b/example/example.js
@@ -161,7 +161,11 @@ var App = React.createClass({
             </p>
           </div>
         </Draggable>
-
+        <div style={{ transform: 'scale(1.25)' }}>
+          <Draggable scale={1.25} {...dragHandlers}>
+            <div className="box">My parent div is scaled to 1.25 and I still drag correctly.</div>
+          </Draggable>
+        </div>
       </div>
     );
   }

--- a/lib/Draggable.js
+++ b/lib/Draggable.js
@@ -29,6 +29,7 @@ export type DraggableProps = {
   defaultClassNameDragged: string,
   defaultPosition: ControlPosition,
   position: ControlPosition,
+  scale: number
 };
 
 //
@@ -146,6 +147,8 @@ export default class Draggable extends React.Component<DraggableProps, Draggable
       y: PropTypes.number
     }),
 
+    scale: PropTypes.number,
+
     /**
      * These properties should be defined on the child, not here.
      */
@@ -162,7 +165,8 @@ export default class Draggable extends React.Component<DraggableProps, Draggable
     defaultClassNameDragging: 'react-draggable-dragging',
     defaultClassNameDragged: 'react-draggable-dragged',
     defaultPosition: {x: 0, y: 0},
-    position: null
+    position: null,
+    scale: 1
   };
 
   constructor(props: DraggableProps) {

--- a/lib/utils/positionFns.js
+++ b/lib/utils/positionFns.js
@@ -103,12 +103,13 @@ export function createCoreData(draggable: DraggableCore, x: number, y: number): 
 
 // Create an data exposed by <Draggable>'s events
 export function createDraggableData(draggable: Draggable, coreData: DraggableData): DraggableData {
+  const {scale} = draggable.props;
   return {
     node: coreData.node,
-    x: draggable.state.x + coreData.deltaX,
-    y: draggable.state.y + coreData.deltaY,
-    deltaX: coreData.deltaX,
-    deltaY: coreData.deltaY,
+    x: draggable.state.x + (coreData.deltaX / scale),
+    y: draggable.state.y + (coreData.deltaY / scale),
+    deltaX: coreData.deltaX / scale,
+    deltaY: coreData.deltaY / scale,
     lastX: draggable.state.x,
     lastY: draggable.state.y
   };

--- a/specs/draggable.spec.jsx
+++ b/specs/draggable.spec.jsx
@@ -40,6 +40,7 @@ describe('react-draggable', function () {
 
       assert(drag.props.axis === 'both');
       assert(drag.props.handle === null);
+      assert(drag.props.scale === 1);
       assert(drag.props.cancel === null);
       assert(drag.props.bounds == false);
       assert(typeof drag.props.onStart === 'function');


### PR DESCRIPTION
Based on this original PR: https://github.com/mzabriskie/react-draggable/pull/217/files, but removed conflicts with dist files. 

Also, added an additional test to check for scale prop and an example for the example page. Wasn't sure if we wanted the scale in DraggableCore, but can add it if desired. 

@STRML, let me know if any changes are needed and I can get them in Thanks for maintaining this awesome library! 