### PR TITLE
Fix Iframe sticky click with IE11/Edge

### DIFF
--- a/lib/DraggableCore.js
+++ b/lib/DraggableCore.js
@@ -289,8 +289,13 @@ export default class DraggableCore extends React.Component<DraggableCoreProps, D
     // this element. We use different events depending on whether or not we have detected that this
     // is a touch-capable device.
     addEvent(ownerDocument, dragEventFor.move, this.handleDrag);
-    // to fix when using iframe on IE11/edge, it gets sticky click
-    addEvent(ownerDocument.defaultView.top, dragEventFor.stop, this.handleDragStop);
+    // cross-origin
+    try {
+      // to fix when using iframe on IE11/edge, it gets sticky click
+      addEvent(ownerDocument.defaultView.top, dragEventFor.stop, this.handleDragStop);
+    } catch(e) {
+      addEvent(ownerDocument, dragEventFor.stop, this.handleDragStop);
+    }
   };
 
   handleDrag: EventHandler<MouseTouchEvent> = (e) => {
@@ -368,6 +373,7 @@ export default class DraggableCore extends React.Component<DraggableCoreProps, D
       // Remove event handlers
       log('DraggableCore: Removing handlers');
       removeEvent(thisNode.ownerDocument, dragEventFor.move, this.handleDrag);
+      removeEvent(thisNode.ownerDocument, dragEventFor.stop, this.handleDragStop);
       removeEvent(thisNode.ownerDocument.defaultView.top, dragEventFor.stop, this.handleDragStop);
     }
   };

--- a/lib/DraggableCore.js
+++ b/lib/DraggableCore.js
@@ -222,7 +222,12 @@ export default class DraggableCore extends React.Component<DraggableCoreProps, D
       const {ownerDocument} = thisNode;
       removeEvent(ownerDocument, eventsFor.mouse.move, this.handleDrag);
       removeEvent(ownerDocument, eventsFor.touch.move, this.handleDrag);
-      removeEvent(ownerDocument, eventsFor.mouse.stop, this.handleDragStop);
+      try {
+        removeEvent(ownerDocument.defaultView.top, eventsFor.mouse.stop, this.handleDragStop);
+      } catch(e) {
+        removeEvent(ownerDocument, eventsFor.mouse.stop, this.handleDragStop);
+      }
+      // removeEvent(ownerDocument, eventsFor.mouse.stop, this.handleDragStop);
       removeEvent(ownerDocument, eventsFor.touch.stop, this.handleDragStop);
       if (this.props.enableUserSelectHack) removeUserSelectStyles(ownerDocument);
     }
@@ -373,8 +378,12 @@ export default class DraggableCore extends React.Component<DraggableCoreProps, D
       // Remove event handlers
       log('DraggableCore: Removing handlers');
       removeEvent(thisNode.ownerDocument, dragEventFor.move, this.handleDrag);
-      removeEvent(thisNode.ownerDocument, dragEventFor.stop, this.handleDragStop);
-      removeEvent(thisNode.ownerDocument.defaultView.top, dragEventFor.stop, this.handleDragStop);
+      // for cross-origin
+      try {
+        removeEvent(thisNode.ownerDocument.defaultView.top, dragEventFor.stop, this.handleDragStop);
+      } catch(e) {
+        removeEvent(thisNode.ownerDocument, dragEventFor.stop, this.handleDragStop);
+      }
     }
   };
 

--- a/lib/DraggableCore.js
+++ b/lib/DraggableCore.js
@@ -289,7 +289,8 @@ export default class DraggableCore extends React.Component<DraggableCoreProps, D
     // this element. We use different events depending on whether or not we have detected that this
     // is a touch-capable device.
     addEvent(ownerDocument, dragEventFor.move, this.handleDrag);
-    addEvent(ownerDocument, dragEventFor.stop, this.handleDragStop);
+    // to fix when using iframe on IE11/edge, it gets sticky click
+    addEvent(ownerDocument.defaultView.top, dragEventFor.stop, this.handleDragStop);
   };
 
   handleDrag: EventHandler<MouseTouchEvent> = (e) => {
@@ -367,7 +368,7 @@ export default class DraggableCore extends React.Component<DraggableCoreProps, D
       // Remove event handlers
       log('DraggableCore: Removing handlers');
       removeEvent(thisNode.ownerDocument, dragEventFor.move, this.handleDrag);
-      removeEvent(thisNode.ownerDocument, dragEventFor.stop, this.handleDragStop);
+      removeEvent(thisNode.ownerDocument.defaultView.top, dragEventFor.stop, this.handleDragStop);
     }
   };
 


### PR DESCRIPTION
When using IE, Edge(13, 14 and 15), if this react-draggable is in an iframe, the draggable item gets 'stuck' on the mouse if the user attempts to drag it off iframe/screen.

To reproduce:
1 Make sure react-draggable is in an iframe
2 Open IE browser
3 Try to click/drag the draggable item out of the iframe
4 Release mouse click(outside of the iframe). Observe as the user now moves mouse around the screen, the draggable item follows as if it's stuck to the pointer.