### PR TITLE
Fix 'Cannot read property 'call' of undefined' in matchesSelector

### DIFF
--- a/lib/utils/domFns.js
+++ b/lib/utils/domFns.js
@@ -6,6 +6,10 @@ import type {ControlPosition, MouseTouchEvent} from './types';
 
 let matchesSelectorFunc = '';
 export function matchesSelector(el: Node, selector: string): boolean {
+  if (!(el instanceof Element)) {
+      return false;
+  }
+
   if (!matchesSelectorFunc) {
     matchesSelectorFunc = findInArray([
       'matches',


### PR DESCRIPTION
Also it would be better to type `el: Node` as `el: Element` https://github.com/svsool/react-draggable/blob/e1f7f45cb9e86212e80bd85da8cbef9697783886/lib/utils/domFns.js#L8, because Node interface doesn't provide any matches function see https://developer.mozilla.org/en-US/docs/Web/API/Node comparing to https://developer.mozilla.org/en-US/docs/Web/API/Element/matches