### PR TITLE
Remove process.browser which is missing in browser

### DIFF
--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -1,12 +1,12 @@
 {
   "dist/react-draggable.js": {
-    "bundled": 75241,
-    "minified": 22786,
-    "gzipped": 7678
+    "bundled": 75213,
+    "minified": 22764,
+    "gzipped": 7663
   },
   "dist/react-draggable.min.js": {
-    "bundled": 51426,
-    "minified": 15772,
-    "gzipped": 5609
+    "bundled": 51398,
+    "minified": 15750,
+    "gzipped": 5594
   }
 }

--- a/lib/DraggableCore.js
+++ b/lib/DraggableCore.js
@@ -106,7 +106,7 @@ export default class DraggableCore extends React.Component<DraggableCoreProps, D
      * instead of using the parent node.
      */
     offsetParent: function(props: DraggableCoreProps, propName: $Keys<DraggableCoreProps>) {
-      if (process.browser === true && props[propName] && props[propName].nodeType !== 1) {
+      if (props[propName] && props[propName].nodeType !== 1) {
         throw new Error('Draggable\'s offsetParent must be a DOM Node.');
       }
     },

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "core-js": "^2.5.1",
     "eslint": "^4.12.0",
     "eslint-plugin-react": "^7.5.1",
-    "flow-bin": "^0.59.0",
+    "flow-bin": "^0.69.0",
     "jasmine-core": "^2.8.0",
     "json-loader": "^0.5.7",
     "karma": "^1.7.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2455,9 +2455,9 @@ flat-cache@^1.2.1:
     graceful-fs "^4.1.2"
     write "^0.2.1"
 
-flow-bin@^0.59.0:
-  version "0.59.0"
-  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.59.0.tgz#8c151ee7f09f1deed9bf0b9d1f2e8ab9d470f1bb"
+flow-bin@^0.69.0:
+  version "0.69.0"
+  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.69.0.tgz#053159a684a6051fcbf0b71a2eb19a9679082da6"
 
 for-in@^1.0.1:
   version "1.0.2"


### PR DESCRIPTION
Upgraded flow and found this bug. It should fail in browser. Previously webpack added process polyfill which also increased bundle size.