### PR TITLE
Fixes some issues in the type definitions for TypeScript

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "flow": "flow"
   },
   "typings": "./typings/index.d.ts",
+  "types": "./typings/index.d.ts",
   "repository": {
     "type": "git",
     "url": "https://github.com/mzabriskie/react-draggable.git"

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -18,7 +18,7 @@ declare module 'react-draggable' {
     position: ControlPosition
   }
 
-  export type DraggableEventHandler = (e: MouseEvent, data: DraggableData) => void | false;
+  export type DraggableEventHandler = (e: React.MouseEvent<HTMLElement> | React.TouchEvent<HTMLElement>, data: DraggableData) => void | false;
 
   export interface DraggableData {
     node: HTMLElement,


### PR DESCRIPTION
The current type definitions use native events as parameter type for event listeners. But what is actually passed are instances of React's synthetic events. Also, depending on the input mode either a MouseEvent or a TouchEvent is passed.

The `package.json` currently only has the `typings` property which was used by older versions of TypeScript and leads to issues with current TypeScript versions where it randomly doesn't find the type definitions. Adding a `types` property to indicate the entry file for the type definitions fixes this. This is also what's recommended in the official docs when it comes to publishing NPM packages https://www.typescriptlang.org/docs/handbook/declaration-files/publishing.html