### PR TITLE
Fixes touch scrolling for Safari and event listener error on Chrome

### DIFF
--- a/lib/DraggableCore.js
+++ b/lib/DraggableCore.js
@@ -231,7 +231,7 @@ export default class DraggableCore extends React.Component<DraggableCoreProps, D
   handleDragStart: EventHandler<MouseTouchEvent> = (e) => {
 
     // Disable touch scrolling while dragging on mobile devices.
-    document.ontouchmove = function(e){ e.preventDefault(); };
+    e.target.ontouchmove = function(){ return false; };
 
     // Make it possible to attach event handlers on top of this one.
     this.props.onMouseDown(e);
@@ -340,10 +340,7 @@ export default class DraggableCore extends React.Component<DraggableCoreProps, D
 
   handleDragStop: EventHandler<MouseTouchEvent> = (e) => {
     if (!this.state.dragging) return;
-
-    // Reactivate touch scrolling after dragging action is complete on mobile devices.
-    document.ontouchmove = function(){ return true; };
-
+    
     const position = getControlPosition(e, this.state.touchIdentifier, this);
     if (position == null) return;
     const {x, y} = position;

--- a/lib/DraggableCore.js
+++ b/lib/DraggableCore.js
@@ -229,6 +229,10 @@ export default class DraggableCore extends React.Component<DraggableCoreProps, D
   }
 
   handleDragStart: EventHandler<MouseTouchEvent> = (e) => {
+
+    // Disable touch scrolling while dragging on mobile devices.
+    document.ontouchmove = function(e){ e.preventDefault(); };
+
     // Make it possible to attach event handlers on top of this one.
     this.props.onMouseDown(e);
 
@@ -294,9 +298,6 @@ export default class DraggableCore extends React.Component<DraggableCoreProps, D
 
   handleDrag: EventHandler<MouseTouchEvent> = (e) => {
 
-    // Prevent scrolling on mobile devices, like ipad/iphone.
-    if (e.type === 'touchmove') e.preventDefault();
-
     // Get the current drag point from the event. This is used as the offset.
     const position = getControlPosition(e, this.state.touchIdentifier, this);
     if (position == null) return;
@@ -339,6 +340,9 @@ export default class DraggableCore extends React.Component<DraggableCoreProps, D
 
   handleDragStop: EventHandler<MouseTouchEvent> = (e) => {
     if (!this.state.dragging) return;
+
+    // Reactivate touch scrolling after dragging action is complete on mobile devices.
+    document.ontouchmove = function(){ return true; };
 
     const position = getControlPosition(e, this.state.touchIdentifier, this);
     if (position == null) return;


### PR DESCRIPTION
Issue #227
This addresses a breaking change with newer versions of Chrome (Chrome 56 and newer) which ignores preventDefault in passive event listeners. This resulted in the following error:  

> Unable to preventDefault inside passive event listener invocation.

There is documentation on this change at
[Making touch scrolling fast by default](https://developers.google.com/web/updates/2017/01/scrolling-intervention)

This addresses issue #227 by disabling scrolling at the beginning of a drag action rather than based on styling of an element.

Issue #279
Disables touch scrolling during drag events on newer versions of Safari.