### PR TITLE
Respond to `bounds` change

### DIFF
--- a/lib/Draggable.js
+++ b/lib/Draggable.js
@@ -204,14 +204,35 @@ export default class Draggable extends React.Component<DraggableProps, Draggable
   }
 
   componentWillReceiveProps(nextProps: Object) {
-    // Set x/y if position has changed
-    if (nextProps.position &&
-        (!this.props.position ||
-          nextProps.position.x !== this.props.position.x ||
-          nextProps.position.y !== this.props.position.y
-        )
-      ) {
-      this.setState({ x: nextProps.position.x, y: nextProps.position.y });
+    let boundsChanged;
+    if (typeof nextProps.bounds === 'object' && typeof this.props.bounds === 'object') {
+      boundsChanged = (
+        nextProps.bounds.left !== this.props.bounds.left ||
+        nextProps.bounds.right !== this.props.bounds.right ||
+        nextProps.bounds.top !== this.props.bounds.top ||
+        nextProps.bounds.bottom !== this.props.bounds.bottom
+      );
+    } else {
+      boundsChanged = nextProps.bounds !== this.props.bounds;
+    }
+
+
+    const positionChanged = nextProps.position && (
+                            !this.props.position ||
+                            nextProps.position.x !== this.props.position.x ||
+                            nextProps.position.y !== this.props.position.y
+                          );
+
+    // Set x/y if position has changed or bounds have changed
+    if (positionChanged || boundsChanged) {
+      const { x, y } = nextProps.position || this.state;
+      const [newStateX, newStateY] = getBoundPosition(this, x, y, nextProps.bounds);
+      const outOfBounds = x !== newStateX || y !== newStateY;
+
+      // state set unnecessary if position not changed and already in bounds
+      if (positionChanged || outOfBounds) {
+        this.setState({ x: newStateX, y: newStateY });
+      }
     }
   }
 

--- a/lib/Draggable.js
+++ b/lib/Draggable.js
@@ -11,6 +11,7 @@ import type {ControlPosition, DraggableBounds, DraggableCoreProps} from './Dragg
 import log from './utils/log';
 import type {DraggableEventHandler} from './utils/types';
 import type {Element as ReactElement} from 'react';
+import BoundsObserver from './utils/boundsObserver';
 
 type DraggableState = {
   dragging: boolean,
@@ -36,6 +37,7 @@ export type DraggableProps = {
 //
 
 export default class Draggable extends React.Component<DraggableProps, DraggableState> {
+  boundsObserver: BoundsObserver;
 
   static displayName = 'Draggable';
 
@@ -185,6 +187,8 @@ export default class Draggable extends React.Component<DraggableProps, Draggable
       // Can only determine if SVG after mounting
       isElementSVG: false
     };
+
+    this.boundsObserver = new BoundsObserver(this);
   }
 
   componentWillMount() {
@@ -204,40 +208,36 @@ export default class Draggable extends React.Component<DraggableProps, Draggable
   }
 
   componentWillReceiveProps(nextProps: Object) {
-    let boundsChanged;
-    if (typeof nextProps.bounds === 'object' && typeof this.props.bounds === 'object') {
-      boundsChanged = (
-        nextProps.bounds.left !== this.props.bounds.left ||
-        nextProps.bounds.right !== this.props.bounds.right ||
-        nextProps.bounds.top !== this.props.bounds.top ||
-        nextProps.bounds.bottom !== this.props.bounds.bottom
-      );
-    } else {
-      boundsChanged = nextProps.bounds !== this.props.bounds;
-    }
-
-
-    const positionChanged = nextProps.position && (
-                            !this.props.position ||
-                            nextProps.position.x !== this.props.position.x ||
-                            nextProps.position.y !== this.props.position.y
-                          );
-
-    // Set x/y if position has changed or bounds have changed
-    if (positionChanged || boundsChanged) {
+    if (nextProps.bounds !== this.props.bounds || (
+          typeof nextProps.bounds === 'object' 
+          && typeof this.props.bounds === 'object' 
+          && (
+            Object.keys(nextProps.bounds).length !== Object.keys(this.props.bounds)
+            || Object.keys(nextProps.bounds).some(k => nextProps.bounds[k] !== this.props.bounds[k] 
+          ))
+        )
+      ) {
+      // bounds changed
       const { x, y } = nextProps.position || this.state;
       const [newStateX, newStateY] = getBoundPosition(this, x, y, nextProps.bounds);
-      const outOfBounds = x !== newStateX || y !== newStateY;
-
-      // state set unnecessary if position not changed and already in bounds
-      if (positionChanged || outOfBounds) {
+      if (x !== newStateX || y !== newStateY) {
         this.setState({ x: newStateX, y: newStateY });
       }
+    } else if (nextProps.position &&
+        (!this.props.position ||
+          nextProps.position.x !== this.props.position.x ||
+          nextProps.position.y !== this.props.position.y
+        )
+      ) {
+      // position changed
+      this.setState({ x: nextProps.position.x, y: nextProps.position.y });
     }
   }
 
   componentWillUnmount() {
     this.setState({dragging: false}); // prevents invariant if unmounted while dragging
+    // cleanup if bounds observer is listening
+    if (this.boundsObserver.boundElement) this.boundsObserver.removeBoundElementListener();
   }
 
   onDragStart: DraggableEventHandler = (e, coreData) => {
@@ -274,7 +274,7 @@ export default class Draggable extends React.Component<DraggableProps, Draggable
       newState.y += this.state.slackY;
 
       // Get bound position. This will ceil/floor the x and y within the boundaries.
-      const [newStateX, newStateY] = getBoundPosition(this, newState.x, newState.y);
+      const [newStateX, newStateY] = getBoundPosition(this, newState.x, newState.y, this.props.bounds);
       newState.x = newStateX;
       newState.y = newStateY;
 

--- a/lib/utils/boundsObserver.js
+++ b/lib/utils/boundsObserver.js
@@ -1,0 +1,28 @@
+import ResizeObserver from 'resize-observer-polyfill';
+
+import type Draggable from '../Draggable';
+import { getBoundPosition } from './positionFns';
+
+export default class BoundsObserver {
+  boundElement: HTMLElement;
+
+  constructor(draggable: Draggable) {
+    this.ro = new ResizeObserver(() => {
+      const [x, y] = getBoundPosition(draggable, draggable.state.x, draggable.state.y, draggable.bounds);
+      draggable.setState({ x, y });
+    });
+  }
+
+  addBoundElementListener(e: HTMLElement) {
+    if (this.boundElement) {
+      this.ro.unobserve(this.boundElement);
+    }
+    this.boundElement = e;
+    this.ro.observe(this.boundElement);
+  }
+
+  removeBoundElementListener() {
+    this.ro.unobserve(this.boundElement);
+    this.boundElement = undefined;
+  }
+}

--- a/lib/utils/positionFns.js
+++ b/lib/utils/positionFns.js
@@ -29,9 +29,13 @@ export function getBoundPosition(
     } else {
       boundNode = ownerDocument.querySelector(bounds);
     }
+
     if (!(boundNode instanceof HTMLElement)) {
       throw new Error('Bounds selector "' + bounds + '" could not find an element.');
     }
+    // Add a resize listener for the bound node
+    draggable.boundsObserver.addBoundElementListener(boundNode);
+    
     const nodeStyle = ownerWindow.getComputedStyle(node);
     const boundNodeStyle = ownerWindow.getComputedStyle(boundNode);
     // Compute bounds. This is a pain with padding and offsets but this gets it exactly right.

--- a/lib/utils/positionFns.js
+++ b/lib/utils/positionFns.js
@@ -7,12 +7,16 @@ import type Draggable from '../Draggable';
 import type {Bounds, ControlPosition, DraggableData, MouseTouchEvent} from './types';
 import type DraggableCore from '../DraggableCore';
 
-export function getBoundPosition(draggable: Draggable, x: number, y: number): [number, number] {
+export function getBoundPosition(
+  draggable: Draggable,
+  x: number,
+  y: number,
+  bounds?:Bounds|string|false=draggable.props.bounds,
+): [number, number] {
   // If no bounds, short-circuit and move on
-  if (!draggable.props.bounds) return [x, y];
+  if (!bounds) return [x, y];
 
   // Clone new bounds
-  let {bounds} = draggable.props;
   bounds = typeof bounds === 'string' ? bounds : cloneBounds(bounds);
   const node = findDOMNode(draggable);
 

--- a/package.json
+++ b/package.json
@@ -88,6 +88,7 @@
   ],
   "dependencies": {
     "classnames": "^2.2.5",
-    "prop-types": "^15.6.0"
+    "prop-types": "^15.6.0",
+    "resize-observer-polyfill": "^1.5.0"
   }
 }


### PR DESCRIPTION
Inspired by PR #348, I added some additional logic so if the specified `bound` is an HTML element a ResizeObserver will watch for changes and update the bounds + coords appropriately. 

I'll admit I have zero Flow experience so somewhat off the cuff in that regard. Seems to be a linting issue related to that that I am a bit uncertain on how to resolve.

This _does_ add a dependency (albeit fairly small at 2.5K), but ideally that can be removed once the `ResizeObserver` API is supported in all browsers (is already in Chrome and close in [FF](https://bugzilla.mozilla.org/show_bug.cgi?id=1272409)).

[`ResizeObserver CanIUse`](https://caniuse.com/#feat=resizeobserver)

/cc @STRML @mzabriskie 

Initial work credit to @travisoneill

NOTE: Can add tests if feature/functionality is approved.