### PR TITLE
Fix compare where portal elements are different instance to main window

### DIFF
--- a/lib/utils/positionFns.js
+++ b/lib/utils/positionFns.js
@@ -25,7 +25,7 @@ export function getBoundPosition(draggable: Draggable, x: number, y: number): [n
     } else {
       boundNode = ownerDocument.querySelector(bounds);
     }
-    if (!(boundNode instanceof HTMLElement)) {
+    if (!(boundNode instanceof ownerWindow.HTMLElement)) {
       throw new Error('Bounds selector "' + bounds + '" could not find an element.');
     }
     const nodeStyle = ownerWindow.getComputedStyle(node);


### PR DESCRIPTION
Fixes an issue where if you use the react portals with a window.open, the HTMLElement in the window is a different instance to the one in the main window, meaning you would always get an error.