### PR TITLE
Correct typing of DraggableEventHandler

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -18,7 +18,13 @@ declare module 'react-draggable' {
     position: ControlPosition
   }
 
-  export type DraggableEventHandler = (e: React.MouseEvent<HTMLElement> | React.TouchEvent<HTMLElement>, data: DraggableData) => void | false;
+  export type DraggableEventHandler = (
+    e: React.MouseEvent<HTMLElement | SVGElement>
+     | React.TouchEvent<HTMLElement | SVGElement>
+     | MouseEvent
+     | TouchEvent,
+    data: DraggableData
+  ) => void | false;
 
   export interface DraggableData {
     node: HTMLElement,


### PR DESCRIPTION
Per #373, the typing of `DraggableEventHandler` needs correction to reflect its all complexity.