### PR TITLE
Prevent scrolling on mobile devices, like ipad/iphone.

### DIFF
--- a/lib/DraggableCore.js
+++ b/lib/DraggableCore.js
@@ -221,6 +221,14 @@ export default class DraggableCore extends React.Component<DraggableCoreProps, D
     touchIdentifier: null
   };
 
+  componentDidMount() {
+    const thisNode = ReactDOM.findDOMNode(this);
+    if (thisNode) {
+      // Prevent scrolling on mobile devices, like ipad/iphone.
+      addEvent(thisNode, eventsFor.touch.move, this.handleDrag);
+    }
+  }
+
   componentWillUnmount() {
     // Remove any leftover event handlers. Remove both touch and mouse handlers in case
     // some browser quirk caused a touch event to fire during a mouse move, or vice versa.
@@ -231,6 +239,7 @@ export default class DraggableCore extends React.Component<DraggableCoreProps, D
       removeEvent(ownerDocument, eventsFor.touch.move, this.handleDrag);
       removeEvent(ownerDocument, eventsFor.mouse.stop, this.handleDragStop);
       removeEvent(ownerDocument, eventsFor.touch.stop, this.handleDragStop);
+      removeEvent(thisNode, eventsFor.touch.move, this.handleDrag);
       if (this.props.enableUserSelectHack) removeUserSelectStyles(ownerDocument);
     }
   }


### PR DESCRIPTION
fix #406 

> When dragging in Safari on iDevices (I specifically tested an iPhone 7 and iPad Air 2, both running iOS 10.3) the entire screen scrolls with the drag

It seemed to solve this problem in the past, but it did not work properly.

I add some code. it works.