### PR TITLE
Change link in readme to example source

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ an intermediate wrapper (`<Draggable><span>...</span></Draggable>`) in this case
 ### Draggable Usage
 
 View the [Demo](http://mzabriskie.github.io/react-draggable/example/) and its
-[source](/example/index.html) for more.
+[source](/example/example.js) for more.
 
 ```js
 import React from 'react';


### PR DESCRIPTION
It's far more useful to have the link go to the JS code that was used to create the page rather than the HTML layout of the page