### PR TITLE
fix: upload cjs to npm instead of es2015

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "flow": "flow"
   },
   "files": [
-    "/lib"
+    "build"
   ],
   "typings": "./typings/index.d.ts",
   "types": "./typings/index.d.ts",


### PR DESCRIPTION
My test units crash as below:
```jsx
/home/orzorzorzorz/github/mini-xmind/node_modules/react-draggable/lib/Draggable.js:2
import React from 'react';
       ^^^^^

SyntaxError: Unexpected identifier
```

Close #426