### PR TITLE
Add transform-inline-environment-variables Babel plugin

### DIFF
--- a/.babelrc.js
+++ b/.babelrc.js
@@ -21,6 +21,7 @@ module.exports = {
   "plugins": [
     "@babel/plugin-transform-flow-comments",
     "@babel/plugin-proposal-class-properties",
+    "transform-inline-environment-variables"
   ],
   "env": {
     "test": {

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "babel-eslint": "^10.0.3",
     "babel-loader": "^8.0.6",
     "babel-plugin-espower": "^3.0.1",
+    "babel-plugin-transform-inline-environment-variables": "^0.4.3",
     "eslint": "^6.2.2",
     "eslint-plugin-react": "^7.5.1",
     "flow-bin": "^0.69.0",


### PR DESCRIPTION
The cjs and esm builds introduced 4.1.0 contain references to **process.env.DRAGGABLE_DEBUG**, which is not necessarily replaced by all bundlers out of the box.

My suggestion would be to do the same thing as your Webpack configuration, and rewrite process variables at build time using [babel-plugin-transform-inline-environment-variables](https://babeljs.io/docs/en/babel-plugin-transform-inline-environment-variables).