### PR TITLE
fix: make DraggableBounds properties optional in typings

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -2,10 +2,10 @@ declare module 'react-draggable' {
   import * as React from 'react';
 
   export interface DraggableBounds {
-    left: number
-    right: number
-    top: number
-    bottom: number
+    left?: number
+    right?: number
+    top?: number
+    bottom?: number
   }
 
   export interface DraggableProps extends DraggableCoreProps {


### PR DESCRIPTION
Per #400, the typings for DraggableBounds should allow the properties to be optional.

This updates the types for DraggableBounds to match the documentation and the PropType definitions.