### PR TITLE
Add rem example, closes #480

### DIFF
--- a/example/example.js
+++ b/example/example.js
@@ -141,6 +141,16 @@ class App extends React.Component {
             I already have an absolute position.
           </div>
         </Draggable>
+        <Draggable {...dragHandlers}>
+          <RemWrapper>
+            <div className="box rem-position-fix" style={{position: 'absolute', bottom: '6.25rem', right: '18rem'}}>
+              I use <span style={{ fontWeight: 700 }}>rem</span> instead of <span style={{ fontWeight: 700 }}>px</span> for my transforms. I also have absolute positioning.
+
+              <br /><br />
+              I depend on a CSS hack to avoid double absolute positioning.
+            </div>
+          </RemWrapper>
+        </Draggable>
         <Draggable defaultPosition={{x: 25, y: 25}} {...dragHandlers}>
           <div className="box">
             {"I have a default position of {x: 25, y: 25}, so I'm slightly offset."}
@@ -180,5 +190,45 @@ class App extends React.Component {
     );
   }
 }
+
+class RemWrapper extends React.Component {
+  // PropTypes is not available in this environment, but here they are.
+  // static propTypes = {
+  //   style: PropTypes.shape({
+  //     transform: PropTypes.string.isRequired
+  //   }),
+  //   children: PropTypes.node.isRequired,
+  //   remBaseline: PropTypes.number,
+  // }
+
+  translateTransformToRem(transform, remBaseline = 16) {
+    const convertedValues = transform.replace('translate(', '').replace(')', '')
+      .split(',')
+      .map(px => px.replace('px', ''))
+      .map(px => parseInt(px, 10) / remBaseline)
+      .map(x => `${x}rem`)
+    const [x, y] = convertedValues
+
+    return `translate(${x}, ${y})`
+  }
+
+  render() {
+    const { children, remBaseline = 16, style } = this.props
+    const child = React.Children.only(children)
+
+    const editedStyle = {
+      ...child.props.style,
+      ...style,
+      transform: this.translateTransformToRem(style.transform, remBaseline),
+    }
+
+    return React.cloneElement(child, {
+       ...child.props,
+       ...this.props,
+       style: editedStyle
+    })
+  }
+}
+
 
 ReactDOM.render(<App/>, document.getElementById('container'));

--- a/example/index.html
+++ b/example/index.html
@@ -51,6 +51,16 @@
       padding: 10px;
       float: left;
     }
+
+
+    /*
+     * RemWrapper needs to take it's styles from this element,
+     * and this element can't have an absolute position after it's kicked in.
+     * AFAIK it's not possible to do this directly in the RemWrapper component.
+     */
+    .rem-position-fix {
+      position: static !important;
+    }
   </style>
 </head>
 <body>


### PR DESCRIPTION
As promised! :) I figured that instead of adding a wall of text, I'd just add it to the example gallery instead.