### PR TITLE
Consider ctrl-click as non-left-click

### DIFF
--- a/lib/DraggableCore.js
+++ b/lib/DraggableCore.js
@@ -274,7 +274,12 @@ export default class DraggableCore extends React.Component<DraggableCoreProps, D
     this.props.onMouseDown(e);
 
     // Only accept left-clicks.
-    if (!this.props.allowAnyClick && typeof e.button === 'number' && e.button !== 0) return false;
+    if (!this.props.allowAnyClick) {
+      if ((typeof e.button === 'number' && e.button !== 0) ||
+        e.ctrlKey) {
+        return false;
+      }
+    }
 
     // Get nodes. Be sure to grab relative document (could be iframed)
     const thisNode = this.findDOMNode();


### PR DESCRIPTION
We noticed that the behavior on Draggable was different when right-clicking vs. ctrl-clicking, even though they should be treated the same. This modifies it so ctrl-clicks are not considered as left-clicks.