### PR TITLE
fix(grid): incorrect `x` and `y` passed to onStop

### DIFF
--- a/lib/DraggableCore.js
+++ b/lib/DraggableCore.js
@@ -381,11 +381,8 @@ export default class DraggableCore extends React.Component<DraggableCoreProps, D
 
   handleDragStop: EventHandler<MouseTouchEvent> = (e) => {
     if (!this.state.dragging) return;
-
-    const position = getControlPosition(e, this.state.touchIdentifier, this);
-    if (position == null) return;
-    const {x, y} = position;
-    const coreEvent = createCoreData(this, x, y);
+    // No dragging is possible on stop, so we just echo back lastX & lastY.
+    const coreEvent = createCoreData(this, this.state.lastX, this.state.lastY);
 
     // Call event handler
     const shouldContinue = this.props.onStop(e, coreEvent);


### PR DESCRIPTION
This was caused by `onStop` erroneously recalculating coordinates,
which is not necessary / should not happen in the real world, as `mouseup`
and `touchend` should not pass `clientX` and `clientY` values meaningfully
different than the last corresponding move event. In fact, they are already
ignored by `<Draggable>`.

For this reason, we can simply trust the `lastX` and `lastY` in `onDragStop`,
and pass those back.

Fixes #413, bokuweb/react-rnd#453