### PR TITLE
Filtering onDrag events out when there's no movement.

### DIFF
--- a/lib/DraggableCore.js
+++ b/lib/DraggableCore.js
@@ -344,6 +344,9 @@ export default class DraggableCore extends React.Component<DraggableCoreProps, D
     if (position == null) return;
     let {x, y} = position;
 
+    // Return early if there's no movement to filter non-drag events
+    if (x === this.state.lastX && y === this.state.lastY) return;
+
     // Snap to grid if prop has been provided
     if (Array.isArray(this.props.grid)) {
       let deltaX = x - this.state.lastX, deltaY = y - this.state.lastY;


### PR DESCRIPTION
onDrag events should only run when there is change in position.

It's possible to filter these events in "userland" but this should really be the default behavior for the package, IMO

```tsx
// user land
const onDrag = (event: DraggableEvent, info: DraggableData) => {
  console.log("[ReactDraggable] onDrag");
  const wasDragged = !(info.x === info.lastX && info.y === info.lastY);
  if (wasDragged) {
    console.log("[ReactDraggable] onDragStart", info.deltaX, info.deltaY);
  }
};
```
