### PR TITLE
Adding `react` and `react-dom` as dependencies for Yarn PnP

### DIFF
--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
     "prop-types": "^15.6.0"
   },
   "peerDependencies": {
-    "react": "^16.13.1",
-    "react-dom": "^16.13.1"
+    "react": ">= 16.3.0",
+    "react-dom": ">= 16.3.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -89,7 +89,9 @@
   ],
   "dependencies": {
     "classnames": "^2.2.5",
-    "prop-types": "^15.6.0",
+    "prop-types": "^15.6.0"
+  },
+  "peerDependencies": {
     "react": "^16.13.1",
     "react-dom": "^16.13.1"
   }

--- a/package.json
+++ b/package.json
@@ -89,6 +89,8 @@
   ],
   "dependencies": {
     "classnames": "^2.2.5",
-    "prop-types": "^15.6.0"
+    "prop-types": "^15.6.0",
+    "react": "^16.13.1",
+    "react-dom": "^16.13.1"
   }
 }


### PR DESCRIPTION
Yarn V2 refuses access to packages which are not listed as a dependency. This should help fix it.

Details: https://yarnpkg.com/advanced/rulebook#packages-should-only-ever-require-what-they-formally-list-in-their-dependencies