### PR TITLE
Draggable component freezes when content is changing dynamically.

### DIFF
--- a/lib/utils/domFns.js
+++ b/lib/utils/domFns.js
@@ -31,9 +31,14 @@ export function matchesSelector(el: Node, selector: string): boolean {
 export function matchesSelectorAndParentsTo(el: Node, selector: string, baseNode: Node): boolean {
   let node = el;
   do {
-    if (matchesSelector(node, selector)) return true;
-    if (node === baseNode) return false;
-    node = node.parentNode;
+    try {
+      if (matchesSelector(node, selector)) return true;
+      if (node === baseNode) return false;
+      node = node.parentNode;
+    } catch(err) {
+      // Properly handle querySelector.all() of null
+      return false;
+    }
   } while (node);
 
   return false;


### PR DESCRIPTION
The matchesSelectorAndParents to function throws error when the querySeelctor.all() is being called.
This only happens when the Draggable component uses handle / cancel.