### PR TITLE
Reconcile handling of mouse and touch drag start events

### DIFF
--- a/lib/DraggableCore.js
+++ b/lib/DraggableCore.js
@@ -243,6 +243,7 @@ export default class DraggableCore extends React.Component<DraggableCoreProps, D
     // https://developers.google.com/web/updates/2017/01/scrolling-intervention
     const thisNode = this.findDOMNode();
     if (thisNode) {
+      addEvent(thisNode, eventsFor.mouse.start, this.onMouseDown, {passive: false});
       addEvent(thisNode, eventsFor.touch.start, this.onTouchStart, {passive: false});
     }
   }
@@ -258,6 +259,7 @@ export default class DraggableCore extends React.Component<DraggableCoreProps, D
       removeEvent(ownerDocument, eventsFor.touch.move, this.handleDrag);
       removeEvent(ownerDocument, eventsFor.mouse.stop, this.handleDragStop);
       removeEvent(ownerDocument, eventsFor.touch.stop, this.handleDragStop);
+      removeEvent(thisNode, eventsFor.mouse.start, this.onMouseDown, {passive: false});
       removeEvent(thisNode, eventsFor.touch.start, this.onTouchStart, {passive: false});
       if (this.props.enableUserSelectHack) removeUserSelectStyles(ownerDocument);
     }
@@ -447,7 +449,7 @@ export default class DraggableCore extends React.Component<DraggableCoreProps, D
     return React.cloneElement(React.Children.only(this.props.children), {
       // Note: mouseMove handler is attached to document so it will still function
       // when the user drags quickly and leaves the bounds of the element.
-      onMouseDown: this.onMouseDown,
+      // onMouseDown is added on `componentDidMount` so the click can be cancelled
       onMouseUp: this.onMouseUp,
       // onTouchStart is added on `componentDidMount` so they can be added with
       // {passive: false}, which allows it to cancel. See 


### PR DESCRIPTION
Attach the mousedown event handler to the node, likewise to the touchstart, so that it may be cancelled if needed and otherwise handled more uniformly