### PR TITLE
`grid` prop unused in `handleDragStop`

### DIFF
--- a/lib/DraggableCore.js
+++ b/lib/DraggableCore.js
@@ -389,7 +389,6 @@ export default class DraggableCore extends React.Component<DraggableCoreProps, D
     if (Array.isArray(this.props.grid)) {
       let deltaX = x - this.state.lastX, deltaY = y - this.state.lastY;
       [deltaX, deltaY] = snapToGrid(this.props.grid, deltaX, deltaY);
-      if (!deltaX && !deltaY) return; // skip useless drag
       x = this.state.lastX + deltaX, y = this.state.lastY + deltaY;
     }
 

--- a/lib/DraggableCore.js
+++ b/lib/DraggableCore.js
@@ -384,6 +384,15 @@ export default class DraggableCore extends React.Component<DraggableCoreProps, D
     const position = getControlPosition(e, this.state.touchIdentifier, this);
     if (position == null) return;
     const {x, y} = position;
+
+    // Snap to grid if prop has been provided
+    if (Array.isArray(this.props.grid)) {
+      let deltaX = x - this.state.lastX, deltaY = y - this.state.lastY;
+      [deltaX, deltaY] = snapToGrid(this.props.grid, deltaX, deltaY);
+      if (!deltaX && !deltaY) return; // skip useless drag
+      x = this.state.lastX + deltaX, y = this.state.lastY + deltaY;
+    }
+
     const coreEvent = createCoreData(this, x, y);
 
     // Call event handler

--- a/lib/DraggableCore.js
+++ b/lib/DraggableCore.js
@@ -383,7 +383,7 @@ export default class DraggableCore extends React.Component<DraggableCoreProps, D
 
     const position = getControlPosition(e, this.state.touchIdentifier, this);
     if (position == null) return;
-    const {x, y} = position;
+    let {x, y} = position;
 
     // Snap to grid if prop has been provided
     if (Array.isArray(this.props.grid)) {

--- a/specs/draggable.spec.jsx
+++ b/specs/draggable.spec.jsx
@@ -942,6 +942,33 @@ describe('react-draggable', function () {
       // (element, fromX, fromY, toX, toY)
       simulateMovementFromTo(drag, 0, 0, 100, 100);
     });
+
+    it('should call back with snapped data output when grid prop is provided', function(done) {
+      function onDrag(event, data) {
+        assert(data.x === 99);
+        assert(data.y === 96);
+        assert(data.deltaX === 99);
+        assert(data.deltaY === 96);
+        assert(data.node === ReactDOM.findDOMNode(drag));
+      }
+      function onStop(event, data) {
+        assert(data.x === 99);
+        assert(data.y === 96);
+        // Single drag-and-stop so stop {x, y} is same as drag {x, y}.
+        assert(data.deltaX === 0);
+        assert(data.deltaY === 0);
+        assert(data.node === ReactDOM.findDOMNode(drag));
+        done();
+      }
+      drag = TestUtils.renderIntoDocument(
+        <DraggableCore onDrag={onDrag} onStop={onStop} grid={[9, 16]}>
+          <div />
+        </DraggableCore>
+      );
+
+      // (element, fromX, fromY, toX, toY)
+      simulateMovementFromTo(drag, 0, 0, 100, 100);
+    });
   });
 
 


### PR DESCRIPTION
Related: https://github.com/react-grid-layout/react-draggable/pull/507

Fixes: https://github.com/react-grid-layout/react-draggable/issues/413