### PR TITLE
Better strict mode support

### DIFF
--- a/lib/DraggableCore.js
+++ b/lib/DraggableCore.js
@@ -265,7 +265,7 @@ export default class DraggableCore extends React.Component<DraggableCoreProps, D
   // React Strict Mode compatibility: if `nodeRef` is passed, we will use it instead of trying to find
   // the underlying DOM node ourselves. See the README for more information.
   findDOMNode(): ?HTMLElement {
-    return this.props?.nodeRef?.current ?? ReactDOM.findDOMNode(this);
+    return this.props?.nodeRef ? this.props?.nodeRef?.current : ReactDOM.findDOMNode(this);
   }
 
   handleDragStart: EventHandler<MouseTouchEvent> = (e) => {


### PR DESCRIPTION
If nodeRef passed, but `ref.current` returns undefined it will fall back to the `ReactDOM.findDOMNode` and trigger react error that findDOMNode is deprecated in StrictMode. 

The new behavior makes sure that if nodeRef passed, then `ReactDOM.findDOMNode` will never be used, even if the ref value is undefined