### PR TITLE
fix: add children to the DraggableCoreProps

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -43,6 +43,7 @@ declare module 'react-draggable' {
   export interface DraggableCoreProps {
     allowAnyClick: boolean,
     cancel: string,
+    children?: React.ReactNode,
     disabled: boolean,
     enableUserSelectHack: boolean,
     offsetParent: HTMLElement,


### PR DESCRIPTION
This should fix https://github.com/react-grid-layout/react-draggable/issues/647