### PR TITLE
fix: <DraggableCore> not mounted on DragStart

### DIFF
--- a/lib/DraggableCore.js
+++ b/lib/DraggableCore.js
@@ -265,7 +265,7 @@ export default class DraggableCore extends React.Component<DraggableCoreProps, D
   // React Strict Mode compatibility: if `nodeRef` is passed, we will use it instead of trying to find
   // the underlying DOM node ourselves. See the README for more information.
   findDOMNode(): ?HTMLElement {
-    return this.props?.nodeRef ? this.props?.nodeRef?.current : ReactDOM.findDOMNode(this);
+    return this.props?.nodeRef?.current ? this.props?.nodeRef?.current : ReactDOM.findDOMNode(this);
   }
 
   handleDragStart: EventHandler<MouseTouchEvent> = (e) => {


### PR DESCRIPTION
fix: <DraggableCore> not mounted on DragStart.
