### PR TITLE
remove unnecessary global typescript namespace declaration

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1,67 +1,65 @@
-declare module 'react-draggable' {
-  import * as React from 'react';
+import * as React from 'react';
 
-  export interface DraggableBounds {
-    left?: number
-    right?: number
-    top?: number
-    bottom?: number
-  }
+export interface DraggableBounds {
+  left?: number
+  right?: number
+  top?: number
+  bottom?: number
+}
 
-  export interface DraggableProps extends DraggableCoreProps {
-    axis: 'both' | 'x' | 'y' | 'none',
-    bounds: DraggableBounds | string | false ,
-    defaultClassName: string,
-    defaultClassNameDragging: string,
-    defaultClassNameDragged: string,
-    defaultPosition: ControlPosition,
-    positionOffset: PositionOffsetControlPosition,
-    position: ControlPosition
-  }
+export interface DraggableProps extends DraggableCoreProps {
+  axis: 'both' | 'x' | 'y' | 'none',
+  bounds: DraggableBounds | string | false ,
+  defaultClassName: string,
+  defaultClassNameDragging: string,
+  defaultClassNameDragged: string,
+  defaultPosition: ControlPosition,
+  positionOffset: PositionOffsetControlPosition,
+  position: ControlPosition
+}
 
-  export type DraggableEvent = React.MouseEvent<HTMLElement | SVGElement>
-    | React.TouchEvent<HTMLElement | SVGElement>
-    | MouseEvent
-    | TouchEvent
+export type DraggableEvent = React.MouseEvent<HTMLElement | SVGElement>
+  | React.TouchEvent<HTMLElement | SVGElement>
+  | MouseEvent
+  | TouchEvent
 
-  export type DraggableEventHandler = (
-    e: DraggableEvent,
-    data: DraggableData
-  ) => void | false;
+export type DraggableEventHandler = (
+  e: DraggableEvent,
+  data: DraggableData
+) => void | false;
 
-  export interface DraggableData {
-    node: HTMLElement,
-    x: number, y: number,
-    deltaX: number, deltaY: number,
-    lastX: number, lastY: number
-  }
+export interface DraggableData {
+  node: HTMLElement,
+  x: number, y: number,
+  deltaX: number, deltaY: number,
+  lastX: number, lastY: number
+}
 
-  export type ControlPosition = {x: number, y: number};
+export type ControlPosition = {x: number, y: number};
 
-  export type PositionOffsetControlPosition = {x: number|string, y: number|string};
+export type PositionOffsetControlPosition = {x: number|string, y: number|string};
 
-  export interface DraggableCoreProps {
-    allowAnyClick: boolean,
-    cancel: string,
-    children?: React.ReactNode,
-    disabled: boolean,
-    enableUserSelectHack: boolean,
-    offsetParent: HTMLElement,
-    grid: [number, number],
-    handle: string,
-    nodeRef?: React.RefObject<HTMLElement>,
-    onStart: DraggableEventHandler,
-    onDrag: DraggableEventHandler,
-    onStop: DraggableEventHandler,
-    onMouseDown: (e: MouseEvent) => void,
-    scale: number
-  }
+export interface DraggableCoreProps {
+  allowAnyClick: boolean,
+  cancel: string,
+  children?: React.ReactNode,
+  disabled: boolean,
+  enableUserSelectHack: boolean,
+  offsetParent: HTMLElement,
+  grid: [number, number],
+  handle: string,
+  nodeRef?: React.RefObject<HTMLElement>,
+  onStart: DraggableEventHandler,
+  onDrag: DraggableEventHandler,
+  onStop: DraggableEventHandler,
+  onMouseDown: (e: MouseEvent) => void,
+  scale: number
+}
 
-  export default class Draggable extends React.Component<Partial<DraggableProps>, {}> {
-    static defaultProps : DraggableProps;
-  }
+export default class Draggable extends React.Component<Partial<DraggableProps>, {}> {
+  static defaultProps : DraggableProps;
+}
 
-  export class DraggableCore extends React.Component<Partial<DraggableCoreProps>, {}> {
-    static defaultProps : DraggableCoreProps;
-  }
+export class DraggableCore extends React.Component<Partial<DraggableCoreProps>, {}> {
+  static defaultProps : DraggableCoreProps;
 }


### PR DESCRIPTION
Declaring a global module with `declare module 'react-draggable'` is unnecessary, and can cause type pollution if multiple versions of `react-draggable` end up in a package.

This is exemplified in this repro: https://github.com/pgoldberg/react-draggable-typings-bug

The global module declaration is not necessary. Typescript will appropriately associate the typings with the `react-draggable` module, since the typings are declared in the package.json here: https://github.com/react-grid-layout/react-draggable/blob/44a8c6ed103ec6c0a4dda5faf7f8ebca16f9b325/package.json#L24