### PR TITLE
Update tsconfig.json with forceConsistentCasingInFilenames

### DIFF
--- a/typings/tsconfig.json
+++ b/typings/tsconfig.json
@@ -2,7 +2,8 @@
   "compilerOptions": {
     "noEmit": true,
     "jsx": "preserve",
-    "strict": true
+    "strict": true,
+    "forceConsistentCasingInFileNames": true
   },
   "files": [
     "index.d.ts",


### PR DESCRIPTION
see typescript-config/consistentcasing recommendation from Microsoft Edge Tools

This will ensure that Windows and *nix behave consistently and that imports are case sensitive