### PR TITLE
fix/esm-rollup-clsx

### DIFF
--- a/lib/Draggable.js
+++ b/lib/Draggable.js
@@ -2,7 +2,7 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import ReactDOM from 'react-dom';
-import clsx from 'clsx';
+import { clsx } from 'clsx';
 import {createCSSTransform, createSVGTransform} from './utils/domFns';
 import {canDragX, canDragY, createDraggableData, getBoundPosition} from './utils/positionFns';
 import {dontSetMe} from './utils/shims';

--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
     "test"
   ],
   "dependencies": {
-    "clsx": "^1.1.1",
+    "clsx": "^2.1.1",
     "prop-types": "^15.8.1"
   },
   "peerDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2049,10 +2049,10 @@ clone-deep@^4.0.1:
     kind-of "^6.0.2"
     shallow-clone "^3.0.0"
 
-clsx@^1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/clsx/-/clsx-1.1.1.tgz#98b3134f9abbdf23b2663491ace13c5c03a73188"
-  integrity sha512-6/bPho624p3S2pMyvP5kKBPXnI3ufHLObBFCfgx+LkeR5lg2XYy2hqZqUf45ypD8COn2bhgGJSUE+l5dhNBieA==
+clsx@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/clsx/-/clsx-2.1.1.tgz#eed397c9fd8bd882bfb18deab7102049a2f32999"
+  integrity sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==
 
 color-convert@^1.9.0:
   version "1.9.3"


### PR DESCRIPTION
Upgraded the clsx dependency and changed the default import of [clxs](https://www.npmjs.com/package/clsx) package to a named import.

This allows better compatibility with esm projects that uses rollup / vite.

Related to:

[fix: fix esm support and types](https://github.com/lukeed/clsx/pull/57)

[(0 , _clsx2.default) is not a function](https://github.com/react-grid-layout/react-draggable/issues/667)