### PR TITLE
fix: use flushSync to update state

### DIFF
--- a/lib/Draggable.js
+++ b/lib/Draggable.js
@@ -1,5 +1,6 @@
 // @flow
 import * as React from 'react';
+import { flushSync } from "react-dom";
 import PropTypes from 'prop-types';
 import ReactDOM from 'react-dom';
 import clsx from 'clsx';
@@ -253,7 +254,9 @@ class Draggable extends React.Component<DraggableProps, DraggableState> {
     // Kills start event on core as well, so move handlers are never bound.
     if (shouldStart === false) return false;
 
-    this.setState({dragging: true, dragged: true});
+    flushSync(() => {
+      this.setState({dragging: true, dragged: true});
+    });
   };
 
   onDrag: DraggableEventHandler = (e, coreData) => {
@@ -300,7 +303,9 @@ class Draggable extends React.Component<DraggableProps, DraggableState> {
     const shouldUpdate = this.props.onDrag(e, uiData);
     if (shouldUpdate === false) return false;
 
-    this.setState(newState);
+    flushSync(() => {
+      this.setState(newState);
+    });
   };
 
   onDragStop: DraggableEventHandler = (e, coreData) => {
@@ -327,7 +332,9 @@ class Draggable extends React.Component<DraggableProps, DraggableState> {
       newState.y = y;
     }
 
-    this.setState(newState);
+    flushSync(() => {
+      this.setState(newState);
+    });
   };
 
   render(): ReactElement<any> {


### PR DESCRIPTION
# Description

Just like https://github.com/react-grid-layout/react-grid-layout/pull/2043 says, `react-draggable` has the same problem from React 18's automatic batching -- cursor desync with dragging panel.

Though it's not quite recommended, but using flushSync is a quick and valid way to solve this. Further improvement needs some refactoring to be done.

# Related issues

https://github.com/react-grid-layout/react-draggable/issues/738

Please help have a look too. Thank you for your contribution. @STRML 