### PR TITLE
fix: add allowMobileScroll prop to allow for clicks to optionally pass through on mobile

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,14 @@ type DraggableData = {
 // If set to `true`, will allow dragging on non left-button clicks.
 allowAnyClick: boolean,
 
+// Default `false` and default behavior before 4.5.0.
+// If set to `true`, the 'touchstart' event will not be prevented,
+// which will allow scrolling inside containers. We recommend
+// using the 'handle' / 'cancel' props when possible instead of enabling this.
+// 
+// See https://github.com/react-grid-layout/react-draggable/issues/728
+allowMobileScroll: boolean,
+
 // Determines which axis the draggable can move. This only affects
 // flushing to the DOM. Callbacks will still include all values.
 // Accepted values:
@@ -201,6 +209,9 @@ defaultPosition: {x: number, y: number},
 
 // If true, will not call any drag handlers.
 disabled: boolean,
+
+// Default `true`. Adds "user-select: none" while dragging to avoid selecting text.
+enableUserSelectHack: boolean,
 
 // Specifies the x and y that dragging should snap to.
 grid: [number, number],
@@ -324,10 +335,10 @@ on itself and thus must have callbacks attached to be useful.
 ```js
 {
   allowAnyClick: boolean,
+  allowMobileScroll: boolean,
   cancel: string,
   disabled: boolean,
   enableUserSelectHack: boolean,
-  allowMobileScroll: boolean,
   offsetParent: HTMLElement,
   grid: [number, number],
   handle: string,

--- a/README.md
+++ b/README.md
@@ -327,7 +327,7 @@ on itself and thus must have callbacks attached to be useful.
   cancel: string,
   disabled: boolean,
   enableUserSelectHack: boolean,
-  doNotPreventMobileScroll: boolean,
+  allowMobileScroll: boolean,
   offsetParent: HTMLElement,
   grid: [number, number],
   handle: string,

--- a/README.md
+++ b/README.md
@@ -327,6 +327,7 @@ on itself and thus must have callbacks attached to be useful.
   cancel: string,
   disabled: boolean,
   enableUserSelectHack: boolean,
+  doNotPreventMobileScroll: boolean,
   offsetParent: HTMLElement,
   grid: [number, number],
   handle: string,

--- a/lib/DraggableCore.js
+++ b/lib/DraggableCore.js
@@ -288,7 +288,7 @@ export default class DraggableCore extends React.Component<DraggableCoreProps> {
 
     // Prevent scrolling on mobile devices, like ipad/iphone.
     // Important that this is after handle/cancel.
-    if (e.type === 'touchstart' && !this.props.doNotPreventMobileScroll) e.preventDefault();
+    if (e.type === 'touchstart' && !this.props.allowMobileScroll) e.preventDefault();
 
     // Set touch identifier in component state if this is a touch event. This allows us to
     // distinguish between individual touches on multitouch screens by identifying which

--- a/lib/DraggableCore.js
+++ b/lib/DraggableCore.js
@@ -288,7 +288,7 @@ export default class DraggableCore extends React.Component<DraggableCoreProps> {
 
     // Prevent scrolling on mobile devices, like ipad/iphone.
     // Important that this is after handle/cancel.
-    if (e.type === 'touchstart') e.preventDefault();
+    if (e.type === 'touchstart' && !this.props.doNotPreventMobileScroll) e.preventDefault();
 
     // Set touch identifier in component state if this is a touch event. This allows us to
     // distinguish between individual touches on multitouch screens by identifying which

--- a/lib/DraggableCore.js
+++ b/lib/DraggableCore.js
@@ -42,6 +42,7 @@ export type PositionOffsetControlPosition = {x: number|string, y: number|string}
 
 export type DraggableCoreDefaultProps = {
   allowAnyClick: boolean,
+  allowMobileScroll: boolean,
   disabled: boolean,
   enableUserSelectHack: boolean,
   onStart: DraggableEventHandler,
@@ -80,6 +81,15 @@ export default class DraggableCore extends React.Component<DraggableCoreProps> {
      * Defaults to `false`.
      */
     allowAnyClick: PropTypes.bool,
+
+    /**
+     * `allowMobileScroll` turns off cancellation of the 'touchstart' event
+     * on mobile devices. Only enable this if you are having trouble with click
+     * events. Prefer using 'handle' / 'cancel' instead.
+     *
+     * Defaults to `false`.
+     */
+    allowMobileScroll: PropTypes.bool,
 
     children: PropTypes.node.isRequired,
 
@@ -213,6 +223,7 @@ export default class DraggableCore extends React.Component<DraggableCoreProps> {
 
   static defaultProps: DraggableCoreDefaultProps = {
     allowAnyClick: false, // by default only accept left click
+    allowMobileScroll: false,
     disabled: false,
     enableUserSelectHack: true,
     onStart: function(){},

--- a/specs/draggable.spec.jsx
+++ b/specs/draggable.spec.jsx
@@ -622,6 +622,18 @@ describe('react-draggable', function () {
       assert.equal(drag.state.dragging, true);
     });
 
+    it('should *not* call preventDefault on touchStart event if "allowMobileScroll"', function () {
+      drag = TestUtils.renderIntoDocument(<Draggable allowMobileScroll={true}><div/></Draggable>);
+
+      const e = new Event('touchstart');
+      // Oddly `e.defaultPrevented` is not changing here. Maybe because we're not mounted to a real doc?
+      let pdCalled = false;
+      e.preventDefault = function() { pdCalled = true; };
+      ReactDOM.findDOMNode(drag).dispatchEvent(e);
+      assert(!pdCalled);
+      assert.equal(drag.state.dragging, true);
+    });
+
     it('should not call preventDefault on touchStart event if not on handle', function () {
       drag = TestUtils.renderIntoDocument(
         <Draggable handle=".handle">

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -42,11 +42,11 @@ declare module 'react-draggable' {
 
   export interface DraggableCoreProps {
     allowAnyClick: boolean,
+    allowMobileScroll: boolean,
     cancel: string,
     children?: React.ReactNode,
     disabled: boolean,
     enableUserSelectHack: boolean,
-    allowMobileScroll: boolean,
     offsetParent: HTMLElement,
     grid: [number, number],
     handle: string,

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -46,6 +46,7 @@ declare module 'react-draggable' {
     children?: React.ReactNode,
     disabled: boolean,
     enableUserSelectHack: boolean,
+    doNotPreventMobileScroll: boolean,
     offsetParent: HTMLElement,
     grid: [number, number],
     handle: string,

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -46,7 +46,7 @@ declare module 'react-draggable' {
     children?: React.ReactNode,
     disabled: boolean,
     enableUserSelectHack: boolean,
-    doNotPreventMobileScroll: boolean,
+    allowMobileScroll: boolean,
     offsetParent: HTMLElement,
     grid: [number, number],
     handle: string,

--- a/typings/test.tsx
+++ b/typings/test.tsx
@@ -20,11 +20,11 @@ ReactDOM.render(
     onDrag={handleDrag}
     onStop={handleStop}
     offsetParent={document.body}
-    allowAnyClick={true}
     onMouseDown={handleMouseDown}
+    allowAnyClick={true}
+    allowMobileScroll={false}
     disabled={true}
     enableUserSelectHack={false}
-    allowMobileScroll={false}
     bounds={false}
     defaultClassName={'draggable'}
     defaultClassNameDragging={'dragging'}

--- a/typings/test.tsx
+++ b/typings/test.tsx
@@ -24,6 +24,7 @@ ReactDOM.render(
     onMouseDown={handleMouseDown}
     disabled={true}
     enableUserSelectHack={false}
+    doNotPreventMobileScroll={false}
     bounds={false}
     defaultClassName={'draggable'}
     defaultClassNameDragging={'dragging'}
@@ -54,7 +55,8 @@ ReactDOM.render(
     onDrag={handleDrag}
     onStop={handleStop}
     offsetParent={document.body}
-    enableUserSelectHack={false}>
+    enableUserSelectHack={false}
+    doNotPreventMobileScroll={false}>
     <div className="foo bar" ref={nodeRefCore}>
       <div className="handle"/>
       <div className="cancel"/>

--- a/typings/test.tsx
+++ b/typings/test.tsx
@@ -24,7 +24,7 @@ ReactDOM.render(
     onMouseDown={handleMouseDown}
     disabled={true}
     enableUserSelectHack={false}
-    doNotPreventMobileScroll={false}
+    allowMobileScroll={false}
     bounds={false}
     defaultClassName={'draggable'}
     defaultClassNameDragging={'dragging'}
@@ -56,7 +56,7 @@ ReactDOM.render(
     onStop={handleStop}
     offsetParent={document.body}
     enableUserSelectHack={false}
-    doNotPreventMobileScroll={false}>
+    allowMobileScroll={false}>
     <div className="foo bar" ref={nodeRefCore}>
       <div className="handle"/>
       <div className="cancel"/>


### PR DESCRIPTION
Fixes https://github.com/react-grid-layout/react-draggable/issues/728

@STRML let me know if this PR looks good to you. Thanks!

Add doNotPreventMobileScroll prop to allow for clicks to optionally pass through on mobile

