### PR TITLE
Fix bounds="selector" functionality when in a Shadow DOM tree.

### DIFF
--- a/lib/utils/positionFns.js
+++ b/lib/utils/positionFns.js
@@ -22,8 +22,14 @@ export function getBoundPosition(draggable: Draggable, x: number, y: number): [n
     if (bounds === 'parent') {
       boundNode = node.parentNode;
     } else {
-      boundNode = ownerDocument.querySelector(bounds);
+      // Flow assigns the wrong return type (Node) for getRootNode(),
+      // so we cast it to one of the correct types (Element).
+      // The others are Document and ShadowRoot.
+      // All three implement querySelector() so it's safe to call.
+      const rootNode = (((node.getRootNode()): any): Element);
+      boundNode = rootNode.querySelector(bounds);
     }
+
     if (!(boundNode instanceof ownerWindow.HTMLElement)) {
       throw new Error('Bounds selector "' + bounds + '" could not find an element.');
     }

--- a/specs/draggable.spec.jsx
+++ b/specs/draggable.spec.jsx
@@ -807,6 +807,129 @@ describe('react-draggable', function () {
 
     });
 
+    it('should clip dragging to parent, with bounds set to "parent"', function(done){
+      function onDrag(event, data) {
+        assert.equal(data.x, 100);
+        assert.equal(data.y, 100);
+        assert.equal(data.deltaX, 50);
+        assert.equal(data.deltaY, 50);
+        done();
+      }
+      drag = TestUtils.renderIntoDocument(
+        <Draggable onDrag={onDrag} bounds="parent" defaultPosition={{x:50,y:50}}>
+          <div style={{position: 'relative', width:'100px', height:'100px'}} />
+        </Draggable>
+      );
+      const node = ReactDOM.findDOMNode(drag);
+
+      // Create a parent container.
+      const fragment = fragmentFromString(`
+        <div style="position: relative; width: 200px; height: 200px;">
+        </div>
+      `);
+      transplantNodeInto(node, fragment, (f) => f);
+
+
+      // (element, fromX, fromY, toX, toY)
+      simulateMovementFromTo(drag, 50, 50, 350, 350);
+
+    });
+
+    it('should clip dragging to parent, with bounds set to "parent", in a shadow tree', function(done){
+      function onDrag(event, data) {
+        assert.equal(data.x, 100);
+        assert.equal(data.y, 100);
+        assert.equal(data.deltaX, 50);
+        assert.equal(data.deltaY, 50);
+        done();
+      }
+      drag = TestUtils.renderIntoDocument(
+        <Draggable onDrag={onDrag} bounds="parent" defaultPosition={{x:50,y:50}}>
+          <div style={{position: 'relative', width:'100px', height:'100px'}} />
+        </Draggable>
+      );
+      const node = ReactDOM.findDOMNode(drag);
+
+      // Create a parent container.
+      const fragment = fragmentFromString(`
+        <div style="position: relative; width: 200px; height: 200px;">
+        </div>
+      `);
+
+      // Add the parent fragment to a shadow root
+      const div = document.createElement('div');
+      const shadowRoot = div.attachShadow({mode: 'open'});
+      shadowRoot.appendChild(fragment);
+
+      transplantNodeInto(node, shadowRoot, (f) => f.children[0]);
+
+
+      // (element, fromX, fromY, toX, toY)
+      simulateMovementFromTo(drag, 50, 50, 350, 350);
+
+    });
+
+    it('should clip dragging to parent, with bounds set to selector', function(done){
+      function onDrag(event, data) {
+        assert.equal(data.x, 100);
+        assert.equal(data.y, 100);
+        assert.equal(data.deltaX, 50);
+        assert.equal(data.deltaY, 50);
+        done();
+      }
+      drag = TestUtils.renderIntoDocument(
+        <Draggable onDrag={onDrag} bounds="#container" defaultPosition={{x:50,y:50}}>
+          <div style={{position: 'relative', width:'100px', height:'100px'}} />
+        </Draggable>
+      );
+      const node = ReactDOM.findDOMNode(drag);
+
+      // Create a parent container.
+      const fragment = fragmentFromString(`
+        <div id="container" style="position: relative; width: 200px; height: 200px;">
+        </div>
+      `);
+      transplantNodeInto(node, fragment, (f) => f);
+
+
+      // (element, fromX, fromY, toX, toY)
+      simulateMovementFromTo(drag, 50, 50, 350, 350);
+
+    });
+
+    it('should clip dragging to parent, with bounds set to selector, in a shadow tree', function(done){
+      function onDrag(event, data) {
+        assert.equal(data.x, 100);
+        assert.equal(data.y, 100);
+        assert.equal(data.deltaX, 50);
+        assert.equal(data.deltaY, 50);
+        done();
+      }
+      drag = TestUtils.renderIntoDocument(
+        <Draggable onDrag={onDrag} bounds="#container" defaultPosition={{x:50,y:50}}>
+          <div style={{position: 'relative', width:'100px', height:'100px'}} />
+        </Draggable>
+      );
+      const node = ReactDOM.findDOMNode(drag);
+
+      // Create a parent container.
+      const fragment = fragmentFromString(`
+        <div id="container" style="position: relative; width: 200px; height: 200px;">
+        </div>
+      `);
+
+      // Add the parent fragment to a shadow root
+      const div = document.createElement('div');
+      const shadowRoot = div.attachShadow({mode: 'open'});
+      shadowRoot.appendChild(fragment);
+
+      transplantNodeInto(node, shadowRoot, (f) => f.children[0]);
+
+      // (element, fromX, fromY, toX, toY)
+      simulateMovementFromTo(drag, 50, 50, 350, 350);
+
+    });
+
     it('should call back with offset left/top, not client', function(done) {
       function onDrag(event, data) {
         assert.equal(data.x, 100);


### PR DESCRIPTION
Hi! I'm Miguel Calderón and work at PSPDFKit. I'd like to say thanks for your package, which is great!

We've recently switched our SDK container from Iframe to Shadow DOM, and are about to upgrade to React 18, which is bringing up lots of small headaches, mostly caused by our own tech debt.

One of the problems we're finding is using `react-draggable` from within the Shadow DOM when setting the `bounds` prop to a selector.

## Details

The `bounds` prop was not working correctly when set to a selector within a Shadow DOM tree. The reason is that the provided selector was being queried to `ownerDocument` and would throw if the node was attached within a Shadow root.

Here's an example showing the problem: https://playcode.io/1996274

- In the above playground try to drag the square - it will log an error instead.
- If you set `withShadow` to `false` it will work.

The solution applied in this PR is to query the node returned by `node.getRootNode()` instead: this method returns `ownerDocument` when called on the normal DOM as before, but when the node is inside a Shadow root, the shadow root will be returned instead. Additionally, if the node is inside a fragment and not attached to a document nor a Shadow root, the topmost element will be returned.

Some tests have been added as well to cover `bounds` as `parent` as selector, from within a Shadow root and in the normal DOM.