### PR TITLE
fix: ReactDom.findDOMNode is deprecated

### DIFF
--- a/lib/Draggable.js
+++ b/lib/Draggable.js
@@ -45,7 +45,7 @@ export type DraggableProps = {
 
 class Draggable extends React.Component<DraggableProps, DraggableState> {
 
-  private selfNodeRef: Draggable | DraggableCore = React.createRef(null);
+  selfNodeRef: Draggable | DraggableCore = React.createRef(null);
 
   static displayName: ?string = 'Draggable';
 

--- a/lib/Draggable.js
+++ b/lib/Draggable.js
@@ -44,7 +44,9 @@ export type DraggableProps = {
 //
 
 class Draggable extends React.Component<DraggableProps, DraggableState> {
-  selfRef = React.createRef(null)
+
+  private selfNodeRef: Draggable | DraggableCore = React.createRef(null);
+
   static displayName: ?string = 'Draggable';
 
   static propTypes: DraggableProps = {
@@ -244,7 +246,7 @@ class Draggable extends React.Component<DraggableProps, DraggableState> {
   // React Strict Mode compatibility: if `nodeRef` is passed, we will use it instead of trying to find
   // the underlying DOM node ourselves. See the README for more information.
   findDOMNode(): ?HTMLElement {
-    return this.props?.nodeRef?.current ?? this.selfRef;
+    return this.props?.nodeRef?.current ?? this.selfNodeRef;
   }
 
   onDragStart: DraggableEventHandler = (e, coreData) => {

--- a/lib/Draggable.js
+++ b/lib/Draggable.js
@@ -44,7 +44,7 @@ export type DraggableProps = {
 //
 
 class Draggable extends React.Component<DraggableProps, DraggableState> {
-
+  selfRef = React.createRef(null)
   static displayName: ?string = 'Draggable';
 
   static propTypes: DraggableProps = {
@@ -244,7 +244,7 @@ class Draggable extends React.Component<DraggableProps, DraggableState> {
   // React Strict Mode compatibility: if `nodeRef` is passed, we will use it instead of trying to find
   // the underlying DOM node ourselves. See the README for more information.
   findDOMNode(): ?HTMLElement {
-    return this.props?.nodeRef?.current ?? ReactDOM.findDOMNode(this);
+    return this.props?.nodeRef?.current ?? this.selfRef;
   }
 
   onDragStart: DraggableEventHandler = (e, coreData) => {

--- a/lib/utils/positionFns.js
+++ b/lib/utils/positionFns.js
@@ -100,7 +100,7 @@ export function createCoreData(draggable: DraggableCore, x: number, y: number): 
   }
 }
 
-// Create an data exposed by <Draggable>'s events
+// Create a data exposed by <Draggable>'s events
 export function createDraggableData(draggable: Draggable, coreData: DraggableData): DraggableData {
   const scale = draggable.props.scale;
   return {

--- a/package.json
+++ b/package.json
@@ -99,5 +99,6 @@
   "peerDependencies": {
     "react": ">= 16.3.0",
     "react-dom": ">= 16.3.0"
-  }
+  },
+  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }


### PR DESCRIPTION
The method findDOMNode  on React-dom is deprecated on React 19 RC+
Change by createRef