### PR TITLE
Update nodeRef type for React v19 compatibility

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -50,7 +50,7 @@ declare module 'react-draggable' {
     offsetParent: HTMLElement,
     grid: [number, number],
     handle: string,
-    nodeRef?: React.RefObject<HTMLElement>,
+    nodeRef?: React.RefObject<HTMLElement | null>,
     onStart: DraggableEventHandler,
     onDrag: DraggableEventHandler,
     onStop: DraggableEventHandler,


### PR DESCRIPTION
Fixes #768.

See also https://react.dev/blog/2024/04/25/react-19-upgrade-guide#useref-requires-argument.

Only a type change is required, because React's typings (DefinitelyTyped) were changed. The implementation in DraggableCore.js itself already tolerates / guard against `.current==null` everywhere.