### PR TITLE
Fix forgotten requestAnimationFrame call

### DIFF
--- a/lib/DraggableCore.js
+++ b/lib/DraggableCore.js
@@ -3,7 +3,7 @@ import * as React from 'react';
 import PropTypes from 'prop-types';
 import ReactDOM from 'react-dom';
 import {matchesSelectorAndParentsTo, addEvent, removeEvent, addUserSelectStyles, getTouchIdentifier,
-        removeUserSelectStyles} from './utils/domFns';
+        scheduleRemoveUserSelectStyles} from './utils/domFns';
 import {createCoreData, getControlPosition, snapToGrid} from './utils/positionFns';
 import {dontSetMe} from './utils/shims';
 import log from './utils/log';
@@ -265,16 +265,7 @@ export default class DraggableCore extends React.Component<DraggableCoreProps> {
       removeEvent(ownerDocument, eventsFor.mouse.stop, this.handleDragStop);
       removeEvent(ownerDocument, eventsFor.touch.stop, this.handleDragStop);
       removeEvent(thisNode, eventsFor.touch.start, this.onTouchStart, {passive: false});
-      if (this.props.enableUserSelectHack) {
-        // prevent a possible "forced reflow"
-        if (window.requestAnimationFrame) {
-          window.requestAnimationFrame(() => {
-            removeUserSelectStyles(ownerDocument);
-          });
-        } else {
-          removeUserSelectStyles(ownerDocument);
-        }
-      }
+      if (this.props.enableUserSelectHack) scheduleRemoveUserSelectStyles(ownerDocument);
     }
   }
 
@@ -413,7 +404,7 @@ export default class DraggableCore extends React.Component<DraggableCoreProps> {
     const thisNode = this.findDOMNode();
     if (thisNode) {
       // Remove user-select hack
-      if (this.props.enableUserSelectHack) removeUserSelectStyles(thisNode.ownerDocument);
+      if (this.props.enableUserSelectHack) scheduleRemoveUserSelectStyles(thisNode.ownerDocument);
     }
 
     log('DraggableCore: handleDragStop: %j', coreEvent);

--- a/lib/utils/domFns.js
+++ b/lib/utils/domFns.js
@@ -166,7 +166,18 @@ export function addUserSelectStyles(doc: ?Document) {
   if (doc.body) addClassName(doc.body, 'react-draggable-transparent-selection');
 }
 
-export function removeUserSelectStyles(doc: ?Document) {
+export function scheduleRemoveUserSelectStyles(doc: ?Document) {
+  // Prevent a possible "forced reflow"
+  if (window.requestAnimationFrame) {
+    window.requestAnimationFrame(() => {
+      removeUserSelectStyles(doc);
+    });
+  } else {
+    removeUserSelectStyles(doc);
+  }
+}
+
+function removeUserSelectStyles(doc: ?Document) {
   if (!doc) return;
   try {
     if (doc.body) removeClassName(doc.body, 'react-draggable-transparent-selection');


### PR DESCRIPTION
In PR https://github.com/react-grid-layout/react-draggable/pull/556, a performance issue with a forced reflow was fixed, but there was a second case that was forgotten. I've applied the same fix to that case and extracted a scheduling helper so this doesn't accidentally happen again.