### PR TITLE
fix: treat ctrl+click as right-click on macOS

### DIFF
--- a/lib/DraggableCore.js
+++ b/lib/DraggableCore.js
@@ -291,8 +291,8 @@ export default class DraggableCore extends React.Component<DraggableCoreProps> {
     // Make it possible to attach event handlers on top of this one.
     this.props.onMouseDown(e);
 
-    // Only accept left-clicks.
-    if (!this.props.allowAnyClick && typeof e.button === 'number' && e.button !== 0) return false;
+    // Only accept left-clicks. On macOS, ctrl+click is equivalent to right-click.
+    if (!this.props.allowAnyClick && ((typeof e.button === 'number' && e.button !== 0) || e.ctrlKey)) return false;
 
     // Get nodes. Be sure to grab relative document (could be iframed)
     const thisNode = this.findDOMNode();


### PR DESCRIPTION
## Summary

On macOS, ctrl+click opens the context menu (equivalent to right-click). This change prevents drag from starting when ctrl is held during click, matching the expected behavior.

This is a fresh implementation of the fix proposed in #498.

## Changes

- Added `e.ctrlKey` check to the left-click validation in `handleDragStart`
- Updated comment to explain the macOS behavior

## Test plan

- [x] Lint passes
- [x] All 102 unit tests pass
- [x] Manual testing: ctrl+click on a draggable element should NOT start dragging