### PR TITLE
fix(types): remove global module declaration to prevent type pollution

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1,68 +1,66 @@
-declare module 'react-draggable' {
-  import * as React from 'react';
+import * as React from 'react';
 
-  export interface DraggableBounds {
-    left?: number
-    right?: number
-    top?: number
-    bottom?: number
-  }
+export interface DraggableBounds {
+  left?: number
+  right?: number
+  top?: number
+  bottom?: number
+}
 
-  export interface DraggableProps extends DraggableCoreProps {
-    axis: 'both' | 'x' | 'y' | 'none',
-    bounds: DraggableBounds | string | false ,
-    defaultClassName: string,
-    defaultClassNameDragging: string,
-    defaultClassNameDragged: string,
-    defaultPosition: ControlPosition,
-    positionOffset: PositionOffsetControlPosition,
-    position: ControlPosition
-  }
+export interface DraggableProps extends DraggableCoreProps {
+  axis: 'both' | 'x' | 'y' | 'none',
+  bounds: DraggableBounds | string | false ,
+  defaultClassName: string,
+  defaultClassNameDragging: string,
+  defaultClassNameDragged: string,
+  defaultPosition: ControlPosition,
+  positionOffset: PositionOffsetControlPosition,
+  position: ControlPosition
+}
 
-  export type DraggableEvent = React.MouseEvent<HTMLElement | SVGElement>
-    | React.TouchEvent<HTMLElement | SVGElement>
-    | MouseEvent
-    | TouchEvent
+export type DraggableEvent = React.MouseEvent<HTMLElement | SVGElement>
+  | React.TouchEvent<HTMLElement | SVGElement>
+  | MouseEvent
+  | TouchEvent
 
-  export type DraggableEventHandler = (
-    e: DraggableEvent,
-    data: DraggableData
-  ) => void | false;
+export type DraggableEventHandler = (
+  e: DraggableEvent,
+  data: DraggableData
+) => void | false;
 
-  export interface DraggableData {
-    node: HTMLElement,
-    x: number, y: number,
-    deltaX: number, deltaY: number,
-    lastX: number, lastY: number
-  }
+export interface DraggableData {
+  node: HTMLElement,
+  x: number, y: number,
+  deltaX: number, deltaY: number,
+  lastX: number, lastY: number
+}
 
-  export type ControlPosition = {x: number, y: number};
+export type ControlPosition = {x: number, y: number};
 
-  export type PositionOffsetControlPosition = {x: number|string, y: number|string};
+export type PositionOffsetControlPosition = {x: number|string, y: number|string};
 
-  export interface DraggableCoreProps {
-    allowAnyClick: boolean,
-    allowMobileScroll: boolean,
-    cancel: string,
-    children?: React.ReactNode,
-    disabled: boolean,
-    enableUserSelectHack: boolean,
-    offsetParent: HTMLElement,
-    grid: [number, number],
-    handle: string,
-    nodeRef?: React.RefObject<HTMLElement | null>,
-    onStart: DraggableEventHandler,
-    onDrag: DraggableEventHandler,
-    onStop: DraggableEventHandler,
-    onMouseDown: (e: MouseEvent) => void,
-    scale: number
-  }
+export interface DraggableCoreProps {
+  allowAnyClick: boolean,
+  allowMobileScroll: boolean,
+  cancel: string,
+  children?: React.ReactNode,
+  disabled: boolean,
+  enableUserSelectHack: boolean,
+  offsetParent: HTMLElement,
+  grid: [number, number],
+  handle: string,
+  nodeRef?: React.RefObject<HTMLElement | null>,
+  onStart: DraggableEventHandler,
+  onDrag: DraggableEventHandler,
+  onStop: DraggableEventHandler,
+  onMouseDown: (e: MouseEvent) => void,
+  scale: number
+}
 
-  export default class Draggable extends React.Component<Partial<DraggableProps>, {}> {
-    static defaultProps : DraggableProps;
-  }
+export default class Draggable extends React.Component<Partial<DraggableProps>, {}> {
+  static defaultProps : DraggableProps;
+}
 
-  export class DraggableCore extends React.Component<Partial<DraggableCoreProps>, {}> {
-    static defaultProps : DraggableCoreProps;
-  }
+export class DraggableCore extends React.Component<Partial<DraggableCoreProps>, {}> {
+  static defaultProps : DraggableCoreProps;
 }

--- a/typings/tsconfig.json
+++ b/typings/tsconfig.json
@@ -2,7 +2,12 @@
   "compilerOptions": {
     "noEmit": true,
     "jsx": "preserve",
-    "strict": true
+    "strict": true,
+    "moduleResolution": "node",
+    "baseUrl": ".",
+    "paths": {
+      "react-draggable": ["./index.d.ts"]
+    }
   },
   "files": [
     "index.d.ts",


### PR DESCRIPTION
## Summary

Removes the `declare module 'react-draggable'` wrapper from TypeScript definitions and uses direct exports instead. This fixes type pollution issues when multiple versions of react-draggable end up in a project's dependencies.

This is a fresh implementation of the fix proposed in #690.

## Changes

- Removed `declare module 'react-draggable'` wrapper from `typings/index.d.ts`
- Updated `typings/tsconfig.json` to use path mapping for the test file

## Why this works

The global module declaration is unnecessary as TypeScript will automatically associate the typings with the `react-draggable` module since they're declared in package.json. The previous approach caused type pollution in complex dependency scenarios.

See reproduction repo: https://github.com/pgoldberg/react-draggable-typings-bug

## Test plan

- [x] Lint passes (includes TypeScript type checking)
- [x] All 102 unit tests pass