### PR TITLE
feat: add GitHub Pages deployment with cyberpunk theme

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -1,0 +1,27 @@
+name: Build and Deploy to GitHub Pages
+permissions:
+  contents: write
+on:
+  push:
+    tags:
+      - "*"
+  workflow_dispatch:
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout 🛎️
+        uses: actions/checkout@v4
+
+      - name: Install and Build
+        run: |
+          yarn
+          yarn build
+          yarn build-example
+
+      - name: Deploy 🚀
+        uses: JamesIves/github-pages-deploy-action@v4
+        with:
+          branch: gh-pages # The branch the action should deploy to.
+          folder: example # The folder the action should deploy.
+          target-folder: example # The destination. Shouldn't touch other folders.

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 *.iml
 node_modules/
 build/
+example/build/
+coverage/

--- a/README.md
+++ b/README.md
@@ -1,15 +1,17 @@
 # React-Draggable
 
 [![CI](https://github.com/react-grid-layout/react-draggable/actions/workflows/ci.yml/badge.svg)](https://github.com/react-grid-layout/react-draggable/actions/workflows/ci.yml)
-[![npm downloads](https://img.shields.io/npm/dt/react-draggable.svg?maxAge=2592000)](http://npmjs.com/package/react-draggable)
-[![gzip size](http://img.badgesize.io/https://npmcdn.com/react-draggable/build/web/react-draggable.min.js?compression=gzip)]()
-[![version](https://img.shields.io/npm/v/react-draggable.svg)]()
+[![npm version](https://img.shields.io/npm/v/react-draggable.svg)](https://www.npmjs.com/package/react-draggable)
+[![npm downloads](https://img.shields.io/npm/dt/react-draggable.svg)](https://www.npmjs.com/package/react-draggable)
+[![gzip size](https://img.badgesize.io/https://npmcdn.com/react-draggable/build/web/react-draggable.min.js?compression=gzip)](https://npmcdn.com/react-draggable/build/web/react-draggable.min.js)
+
+A simple component for making elements draggable.
+
+[**[Demo](https://react-grid-layout.github.io/react-draggable/example/) | [Changelog](CHANGELOG.md)**]
 
 <p align="center">
   <img src="https://user-images.githubusercontent.com/6365230/95649276-f3a02480-0b06-11eb-8504-e0614a780ba4.gif" />
 </p>
-
-A simple component for making elements draggable.
 
 ```jsx
 <Draggable>
@@ -17,31 +19,19 @@ A simple component for making elements draggable.
 </Draggable>
 ```
 
-- [Demo](http://react-grid-layout.github.io/react-draggable/example/)
-- [Changelog](CHANGELOG.md)
-
-| Version | Compatibility   |
-| ------- | --------------- |
-| 4.x     | React 16.3 - 19 |
-| 3.x     | React 15 - 16   |
-| 2.x     | React 0.14 - 15 |
-
----
-
 ## Table of Contents
 
-- [Installing](#installing)
+- [Installation](#installation)
+- [Compatibility](#compatibility)
 - [Quick Start](#quick-start)
-- [Exports](#exports)
-- [Draggable](#draggable)
-- [Draggable API](#draggable-api)
+- [API](#api)
+  - [Draggable](#draggable)
+  - [DraggableCore](#draggablecore)
 - [Using nodeRef](#using-noderef)
 - [Controlled vs. Uncontrolled](#controlled-vs-uncontrolled)
-- [DraggableCore](#draggablecore)
-- [DraggableCore API](#draggablecore-api)
 - [Contributing](#contributing)
 
-## Installing
+## Installation
 
 ```bash
 npm install react-draggable
@@ -49,231 +39,27 @@ npm install react-draggable
 yarn add react-draggable
 ```
 
-TypeScript types are included.
-
-### UMD Build
-
-A [UMD version](build/web/react-draggable.min.js) is available for use in `<script>` tags or AMD loaders. It expects `React` and `ReactDOM` to be available as globals.
-
-To generate a UMD build from `master`, clone the repository and run `make build`.
-
-## Quick Start
-
-```jsx
-import React, { useRef } from 'react';
-import Draggable from 'react-draggable';
-
-function App() {
-  const nodeRef = useRef(null);
-
-  const handleDrag = (e, data) => {
-    console.log('Dragging:', data.x, data.y);
-  };
-
-  return (
-    <Draggable nodeRef={nodeRef} onDrag={handleDrag}>
-      <div ref={nodeRef}>Drag me!</div>
-    </Draggable>
-  );
-}
-```
-
-## Exports
-
 ```js
 // ES Modules
-import Draggable from 'react-draggable'; // The default
-import { DraggableCore } from 'react-draggable'; // <DraggableCore>
-import Draggable, { DraggableCore } from 'react-draggable'; // Both
+import Draggable from 'react-draggable';
+import { DraggableCore } from 'react-draggable';
 
 // CommonJS
 const Draggable = require('react-draggable');
 const { DraggableCore } = require('react-draggable');
 ```
 
-## `<Draggable>`
+TypeScript types are included.
 
-A `<Draggable>` element wraps an existing element and extends it with new event handlers and styles. It does not create a wrapper element in the DOM.
+## Compatibility
 
-Draggable items are moved using CSS Transforms. This allows items to be dragged regardless of their current positioning (relative, absolute, or static). Elements can also be moved between drags without incident.
+| Version | React Version |
+|---------|---------------|
+| 4.x     | 16.3+         |
+| 3.x     | 15 - 16       |
+| 2.x     | 0.14 - 15     |
 
-If the item you are dragging already has a CSS Transform applied, it will be overwritten by `<Draggable>`. Use an intermediate wrapper (`<Draggable><span>...</span></Draggable>`) in this case.
-
-### Draggable Usage
-
-View the [Demo](http://react-grid-layout.github.io/react-draggable/example/) and its [source](/example/example.js) for more examples.
-
-```jsx
-import React, { useRef, useState } from 'react';
-import Draggable from 'react-draggable';
-
-function App() {
-  const nodeRef = useRef(null);
-  const [position, setPosition] = useState({ x: 0, y: 0 });
-
-  const handleDrag = (e, data) => {
-    setPosition({ x: data.x, y: data.y });
-  };
-
-  return (
-    <Draggable
-      nodeRef={nodeRef}
-      axis="x"
-      handle=".handle"
-      defaultPosition={{ x: 0, y: 0 }}
-      grid={[25, 25]}
-      scale={1}
-      onDrag={handleDrag}
-    >
-      <div ref={nodeRef}>
-        <div className="handle">Drag from here</div>
-        <div>
-          Position: ({position.x}, {position.y})
-        </div>
-      </div>
-    </Draggable>
-  );
-}
-```
-
-### Draggable API
-
-The `<Draggable/>` component transparently adds draggability to its children.
-
-**Note**: Only a single child is allowed or an Error will be thrown.
-
-For the `<Draggable/>` component to correctly attach itself to its child, the child element must support the following props:
-
-- `style` - used to apply the transform CSS
-- `className` - used to apply dragging classes
-- `onMouseDown`, `onMouseUp`, `onTouchStart`, `onTouchEnd` - used to track dragging state
-
-React DOM elements support these by default. For custom components, ensure you spread props to the underlying DOM element.
-
-#### `<Draggable>` Props:
-
-```js
-//
-// Types:
-//
-type DraggableEventHandler = (e: Event, data: DraggableData) => void | false;
-type DraggableData = {
-  node: HTMLElement,
-  // lastX + deltaX === x
-  x: number,
-  y: number,
-  deltaX: number,
-  deltaY: number,
-  lastX: number,
-  lastY: number,
-};
-
-//
-// Props:
-//
-{
-  // If set to `true`, will allow dragging on non left-button clicks.
-  allowAnyClick: boolean,
-
-  // Default `false`. If set to `true`, the 'touchstart' event will not be
-  // prevented, allowing scrolling inside containers. Consider using
-  // 'handle' / 'cancel' props instead when possible.
-  // See https://github.com/react-grid-layout/react-draggable/issues/728
-  allowMobileScroll: boolean,
-
-  // Determines which axis the draggable can move. This only affects
-  // flushing to the DOM. Callbacks will still include all values.
-  // Accepted values:
-  // - `both` allows movement horizontally and vertically (default).
-  // - `x` limits movement to horizontal axis.
-  // - `y` limits movement to vertical axis.
-  // - 'none' stops all movement.
-  axis: 'both' | 'x' | 'y' | 'none',
-
-  // Specifies movement boundaries. Accepted values:
-  // - `parent` restricts movement within the node's offsetParent
-  //    (nearest node with position relative or absolute), or
-  // - a selector, restricts movement within the targeted node
-  // - An object with `left, top, right, and bottom` properties.
-  //   These indicate how far in each direction the draggable
-  //   can be moved.
-  bounds: { left?: number, top?: number, right?: number, bottom?: number } | string,
-
-  // Specifies a selector to be used to prevent drag initialization.
-  // The string is passed to Element.matches, so multiple selectors
-  // are supported: `.first, .second`.
-  // Example: '.body'
-  cancel: string,
-
-  // Class names for draggable UI.
-  // Defaults: 'react-draggable', 'react-draggable-dragging', 'react-draggable-dragged'
-  defaultClassName: string,
-  defaultClassNameDragging: string,
-  defaultClassNameDragged: string,
-
-  // Specifies the `x` and `y` that the dragged item should start at.
-  // This is generally not necessary to use (you can use absolute or relative
-  // positioning of the child directly), but can be helpful for uniformity in
-  // your callbacks and with css transforms.
-  defaultPosition: { x: number, y: number },
-
-  // If true, will not call any drag handlers.
-  disabled: boolean,
-
-  // Default `true`. Adds "user-select: none" while dragging to avoid selecting text.
-  enableUserSelectHack: boolean,
-
-  // Specifies the x and y that dragging should snap to.
-  grid: [number, number],
-
-  // Specifies a selector to be used as the handle that initiates drag.
-  // Example: '.handle'
-  handle: string,
-
-  // If desired, you can provide your own offsetParent for drag calculations.
-  // By default, we use the Draggable's offsetParent. This can be useful for elements
-  // with odd display types or floats.
-  offsetParent: HTMLElement,
-
-  // Called whenever the user mouses down. Called regardless of handle or
-  // disabled status.
-  onMouseDown: (e: MouseEvent) => void,
-
-  // Called when dragging starts. If `false` is returned, the action will cancel.
-  onStart: DraggableEventHandler,
-
-  // Called while dragging.
-  onDrag: DraggableEventHandler,
-
-  // Called when dragging stops.
-  onStop: DraggableEventHandler,
-
-  // Ref to the DOM node being dragged. Required for React Strict Mode.
-  // See "Using nodeRef" section below.
-  nodeRef: React.RefObject<HTMLElement>,
-
-  // If this property is present, the item becomes 'controlled' and is not
-  // responsive to user input. Use `position` if you need direct control
-  // of the element.
-  position: { x: number, y: number },
-
-  // A position offset to start with. Differs from `defaultPosition` in that
-  // it does not affect the position returned in draggable callbacks, and
-  // accepts strings like `{x: '10%', y: '10%'}`.
-  positionOffset: { x: number | string, y: number | string },
-
-  // Specifies the scale of the canvas you are dragging on. This allows
-  // correct drag deltas when zoomed in/out via a transform or matrix
-  // in the parent of this element.
-  scale: number
-}
-```
-
-Note that sending `className`, `style`, or `transform` as properties will error - set them on the child element directly.
-
-## Using nodeRef
-
-To avoid `ReactDOM.findDOMNode()` deprecation warnings in React Strict Mode, pass a `nodeRef` prop:
+## Quick Start
 
 ```jsx
 import React, { useRef } from 'react';
@@ -290,16 +76,104 @@ function App() {
 }
 ```
 
-For custom components, you need to forward both the ref and props to the underlying DOM element:
+View the [Demo](https://react-grid-layout.github.io/react-draggable/example/) and its [source](/example/example.js) for more examples.
+
+## API
+
+### `<Draggable>`
+
+A `<Draggable>` element wraps an existing element and extends it with new event handlers and styles. It does not create a wrapper element in the DOM.
+
+Draggable items are moved using CSS Transforms. This allows items to be dragged regardless of their current positioning (relative, absolute, or static). Elements can also be moved between drags without incident.
+
+If the item you are dragging already has a CSS Transform applied, it will be overwritten by `<Draggable>`. Use an intermediate wrapper (`<Draggable><span>...</span></Draggable>`) in this case.
+
+#### Props
+
+```ts
+type DraggableEventHandler = (e: Event, data: DraggableData) => void | false;
+
+type DraggableData = {
+  node: HTMLElement,
+  x: number, y: number,
+  deltaX: number, deltaY: number,
+  lastX: number, lastY: number,
+};
+```
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `allowAnyClick` | `boolean` | `false` | Allow dragging on non-left-button clicks |
+| `allowMobileScroll` | `boolean` | `false` | Don't prevent `touchstart`, allowing scrolling inside containers |
+| `axis` | `'both' \| 'x' \| 'y' \| 'none'` | `'both'` | Axis to allow dragging on |
+| `bounds` | `object \| string` | - | Restrict movement. Use `'parent'`, a CSS selector, or `{left, top, right, bottom}` |
+| `cancel` | `string` | - | CSS selector for elements that should not initiate drag |
+| `defaultClassName` | `string` | `'react-draggable'` | Class name applied to the element |
+| `defaultClassNameDragging` | `string` | `'react-draggable-dragging'` | Class name applied while dragging |
+| `defaultClassNameDragged` | `string` | `'react-draggable-dragged'` | Class name applied after drag |
+| `defaultPosition` | `{x: number, y: number}` | `{x: 0, y: 0}` | Starting position |
+| `disabled` | `boolean` | `false` | Disable dragging |
+| `enableUserSelectHack` | `boolean` | `true` | Add `user-select: none` while dragging |
+| `grid` | `[number, number]` | - | Snap to grid `[x, y]` |
+| `handle` | `string` | - | CSS selector for the drag handle |
+| `nodeRef` | `React.RefObject` | - | Ref to the DOM element. Required for React Strict Mode |
+| `offsetParent` | `HTMLElement` | - | Custom offsetParent for drag calculations |
+| `onDrag` | `DraggableEventHandler` | - | Called while dragging |
+| `onMouseDown` | `(e: MouseEvent) => void` | - | Called on mouse down |
+| `onStart` | `DraggableEventHandler` | - | Called when dragging starts. Return `false` to cancel |
+| `onStop` | `DraggableEventHandler` | - | Called when dragging stops |
+| `position` | `{x: number, y: number}` | - | Controlled position |
+| `positionOffset` | `{x: number \| string, y: number \| string}` | - | Position offset (supports percentages) |
+| `scale` | `number` | `1` | Scale factor for dragging inside transformed parents |
+
+**Note:** Setting `className`, `style`, or `transform` on `<Draggable>` will error. Set them on the child element.
+
+### `<DraggableCore>`
+
+For users that require full control, `<DraggableCore>` provides drag callbacks without managing state or styles. It does not set any transforms; you must handle positioning yourself.
+
+See [React-Resizable](https://github.com/react-grid-layout/react-resizable) and [React-Grid-Layout](https://github.com/react-grid-layout/react-grid-layout) for usage examples.
+
+#### Props
+
+`<DraggableCore>` accepts a subset of `<Draggable>` props:
+
+- `allowAnyClick`
+- `allowMobileScroll`
+- `cancel`
+- `disabled`
+- `enableUserSelectHack`
+- `grid`
+- `handle`
+- `nodeRef`
+- `offsetParent`
+- `onDrag`
+- `onMouseDown`
+- `onStart`
+- `onStop`
+- `scale`
+
+## Using nodeRef
+
+To avoid `ReactDOM.findDOMNode()` deprecation warnings in React Strict Mode, pass a `nodeRef` prop:
 
 ```jsx
-import React, { useRef, forwardRef } from 'react';
-import Draggable from 'react-draggable';
+function App() {
+  const nodeRef = useRef(null);
 
+  return (
+    <Draggable nodeRef={nodeRef}>
+      <div ref={nodeRef}>Drag me!</div>
+    </Draggable>
+  );
+}
+```
+
+For custom components, forward both the ref and props:
+
+```jsx
 const MyComponent = forwardRef((props, ref) => (
-  <div {...props} ref={ref}>
-    Draggable content
-  </div>
+  <div {...props} ref={ref}>Draggable content</div>
 ));
 
 function App() {
@@ -313,13 +187,11 @@ function App() {
 }
 ```
 
-`nodeRef` is also available on `<DraggableCore>`.
-
 ## Controlled vs. Uncontrolled
 
-`<Draggable>` is a 'batteries-included' component that manages its own state. If you want complete control over the lifecycle, use `<DraggableCore>`.
+`<Draggable>` is a 'batteries-included' component that manages its own state. For complete control, use `<DraggableCore>`.
 
-For programmatic repositioning while still using `<Draggable>`'s state management, pass the `position` prop:
+For programmatic repositioning while using `<Draggable>`'s state management, pass the `position` prop:
 
 ```jsx
 function ControlledDraggable() {
@@ -330,9 +202,7 @@ function ControlledDraggable() {
     setPosition({ x: data.x, y: data.y });
   };
 
-  const resetPosition = () => {
-    setPosition({ x: 0, y: 0 });
-  };
+  const resetPosition = () => setPosition({ x: 0, y: 0 });
 
   return (
     <>
@@ -345,63 +215,19 @@ function ControlledDraggable() {
 }
 ```
 
-When `position` is defined, `<Draggable>` uses the provided position instead of its internal state. You should use at least an `onDrag` or `onStop` handler to synchronize state.
-
-To disable dragging while controlled, pass `disabled={true}`.
-
-## `<DraggableCore>`
-
-For users that require absolute control, `<DraggableCore>` is available. This is useful as an abstraction over touch and mouse events, but with full control. `<DraggableCore>` has no internal state.
-
-See [React-Resizable](https://github.com/react-grid-layout/react-resizable) and [React-Grid-Layout](https://github.com/react-grid-layout/react-grid-layout) for usage examples.
-
-`<DraggableCore>` is a building block for libraries that want to abstract browser-specific quirks and receive callbacks when a user attempts to move an element. It does not set styles or transforms on itself, so callbacks must be attached to be useful.
-
-### DraggableCore API
-
-`<DraggableCore>` takes a limited subset of options:
-
-```js
-{
-  allowAnyClick: boolean,
-  allowMobileScroll: boolean,
-  cancel: string,
-  disabled: boolean,
-  enableUserSelectHack: boolean,
-  offsetParent: HTMLElement,
-  grid: [number, number],
-  handle: string,
-  nodeRef: React.RefObject<HTMLElement>,
-  onStart: DraggableEventHandler,
-  onDrag: DraggableEventHandler,
-  onStop: DraggableEventHandler,
-  onMouseDown: (e: MouseEvent) => void,
-  scale: number
-}
-```
-
-Note that there is no start position. `<DraggableCore>` simply calls drag handlers with position data (as inferred from the underlying MouseEvent) and deltas. It is up to the parent to set actual positions on `<DraggableCore>`.
-
-Drag callbacks (`onStart`, `onDrag`, `onStop`) are called with the [same arguments as `<Draggable>`](#draggable-api).
-
----
-
 ## Contributing
 
 - Fork the project
-- Run the project in development mode: `yarn dev`
-- Make changes
-- Add appropriate tests
-- `yarn test`
-- If tests don't pass, make them pass
-- Update README with appropriate docs
-- Commit and PR
+- Run `yarn dev` to start the development server
+- Make changes and add tests
+- Run `yarn test` to ensure tests pass
+- Submit a PR
 
-### Release checklist
+### Release Checklist
 
-- Update CHANGELOG
-- `make release-patch`, `make release-minor`, or `make release-major`
-- `make publish`
+1. Update CHANGELOG.md
+2. Run `make release-patch`, `make release-minor`, or `make release-major`
+3. Run `make publish`
 
 ## License
 

--- a/example/example-styles.css
+++ b/example/example-styles.css
@@ -1,0 +1,347 @@
+/* === CYBERPUNK THEME === */
+@import url('https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;700&family=Orbitron:wght@400;700;900&display=swap');
+
+:root {
+  --cyber-bg: #0a0a0f;
+  --cyber-surface: #12121a;
+  --cyber-cyan: #00f0ff;
+  --cyber-magenta: #ff00aa;
+  --cyber-purple: #a855f7;
+  --cyber-yellow: #facc15;
+  --cyber-grid: rgba(0, 240, 255, 0.03);
+  --glow-cyan: 0 0 20px rgba(0, 240, 255, 0.5), 0 0 40px rgba(0, 240, 255, 0.2);
+  --glow-magenta: 0 0 20px rgba(255, 0, 170, 0.5), 0 0 40px rgba(255, 0, 170, 0.2);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  padding: 0;
+  background: var(--cyber-bg);
+  background-image:
+    linear-gradient(var(--cyber-grid) 1px, transparent 1px),
+    linear-gradient(90deg, var(--cyber-grid) 1px, transparent 1px);
+  background-size: 50px 50px;
+  min-height: 100vh;
+  font-family: 'JetBrains Mono', monospace;
+  color: #e0e0e0;
+}
+
+/* === MAIN CONTENT === */
+.main-content {
+  padding: 20px 30px;
+  min-height: 100vh;
+  max-width: 1400px;
+  margin: 0 auto;
+}
+
+#container {
+  width: 100%;
+}
+
+/* === HEADER === */
+.main-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 20px;
+  padding-bottom: 15px;
+  border-bottom: 1px solid rgba(0, 240, 255, 0.3);
+}
+
+h1 {
+  font-family: 'Orbitron', sans-serif;
+  font-size: 24px;
+  font-weight: 700;
+  color: var(--cyber-cyan);
+  text-shadow: var(--glow-cyan);
+  letter-spacing: 1px;
+  margin: 0;
+}
+
+h3 {
+  font-family: 'Orbitron', sans-serif;
+  font-size: 18px;
+  font-weight: 700;
+  color: var(--cyber-cyan);
+  text-shadow: var(--glow-cyan);
+  letter-spacing: 1px;
+  margin: 0 0 15px 0;
+}
+
+.version-badge {
+  font-size: 13px;
+  font-family: 'JetBrains Mono', monospace;
+  color: var(--cyber-magenta);
+  background: rgba(255, 0, 170, 0.15);
+  padding: 6px 12px;
+  border: 1px solid rgba(255, 0, 170, 0.4);
+  text-decoration: none;
+  text-shadow: 0 0 10px rgba(255, 0, 170, 0.5);
+  transition: all 0.2s ease;
+  flex-shrink: 0;
+}
+
+.version-badge:hover {
+  color: var(--cyber-yellow);
+  border-color: var(--cyber-yellow);
+  background: rgba(250, 204, 21, 0.15);
+  text-shadow: 0 0 15px rgba(250, 204, 21, 0.7);
+}
+
+.header-links {
+  display: flex;
+  gap: 12px;
+  align-items: center;
+}
+
+.lib-link {
+  font-size: 13px;
+  font-family: 'JetBrains Mono', monospace;
+  color: var(--cyber-cyan);
+  background: rgba(0, 240, 255, 0.1);
+  padding: 6px 12px;
+  border: 1px solid rgba(0, 240, 255, 0.4);
+  text-decoration: none;
+  text-shadow: 0 0 10px rgba(0, 240, 255, 0.5);
+  transition: all 0.2s ease;
+}
+
+.lib-link:hover {
+  color: var(--cyber-magenta);
+  border-color: var(--cyber-magenta);
+  background: rgba(255, 0, 170, 0.15);
+  text-shadow: 0 0 15px rgba(255, 0, 170, 0.7);
+}
+
+/* === NAVIGATION LINKS === */
+.nav-links {
+  list-style: none;
+  padding: 0;
+  margin: 0 0 25px 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.nav-links li {
+  background: linear-gradient(135deg, rgba(18, 18, 26, 0.9) 0%, rgba(10, 10, 15, 0.95) 100%);
+  border: 1px solid rgba(0, 240, 255, 0.3);
+  border-left: 3px solid var(--cyber-cyan);
+  padding: 8px 14px;
+  font-size: 13px;
+  transition: all 0.2s ease;
+}
+
+.nav-links li:hover {
+  border-color: var(--cyber-magenta);
+  border-left-color: var(--cyber-magenta);
+  box-shadow: var(--glow-magenta);
+}
+
+.nav-links li a {
+  color: #c0c0c0;
+  text-decoration: none;
+  transition: color 0.2s ease;
+}
+
+.nav-links li a:hover {
+  color: var(--cyber-magenta);
+}
+
+/* === PARAGRAPHS === */
+p {
+  color: #a0a0a0;
+  line-height: 1.6;
+  margin-bottom: 15px;
+  padding-left: 12px;
+  border-left: 2px solid rgba(168, 85, 247, 0.4);
+}
+
+p code {
+  background: rgba(168, 85, 247, 0.2);
+  border: 1px solid var(--cyber-purple);
+  padding: 2px 8px;
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 12px;
+  color: var(--cyber-purple);
+}
+
+p a {
+  color: var(--cyber-cyan);
+  text-decoration: none;
+  transition: color 0.2s ease;
+}
+
+p a:hover {
+  color: var(--cyber-magenta);
+}
+
+/* === DRAGGABLE BOXES === */
+.box {
+  background: linear-gradient(145deg, rgba(18, 18, 26, 0.9) 0%, rgba(30, 30, 45, 0.9) 100%);
+  border: 1px solid var(--cyber-cyan);
+  width: 180px;
+  height: 180px;
+  margin: 10px;
+  padding: 15px;
+  float: left;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  text-align: center;
+  font-size: 13px;
+  color: #c0c0c0;
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.05),
+    0 4px 20px rgba(0, 0, 0, 0.5);
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+  overflow: hidden;
+}
+
+.box:hover {
+  border-color: var(--cyber-magenta);
+  box-shadow:
+    var(--glow-magenta),
+    inset 0 1px 0 rgba(255, 255, 255, 0.05);
+}
+
+/* === CURSORS === */
+.react-draggable, .cursor {
+  cursor: move;
+}
+.no-cursor {
+  cursor: auto;
+}
+.cursor-y {
+  cursor: ns-resize;
+}
+.cursor-x {
+  cursor: ew-resize;
+}
+
+/* === HANDLE === */
+.react-draggable strong {
+  background: linear-gradient(135deg, rgba(0, 240, 255, 0.2) 0%, rgba(0, 240, 255, 0.1) 100%);
+  border: 1px solid var(--cyber-cyan);
+  display: block;
+  margin-bottom: 10px;
+  padding: 6px 10px;
+  text-align: center;
+  font-weight: 500;
+  color: var(--cyber-cyan);
+  text-shadow: 0 0 8px rgba(0, 240, 255, 0.4);
+  transition: all 0.2s ease;
+}
+
+.react-draggable strong:hover {
+  background: linear-gradient(135deg, rgba(255, 0, 170, 0.2) 0%, rgba(255, 0, 170, 0.1) 100%);
+  border-color: var(--cyber-magenta);
+  color: var(--cyber-magenta);
+  text-shadow: 0 0 10px rgba(255, 0, 170, 0.5);
+}
+
+/* === SPECIAL STATES === */
+.no-pointer-events {
+  pointer-events: none;
+}
+
+.hovered {
+  background: linear-gradient(145deg, rgba(255, 0, 170, 0.2) 0%, rgba(30, 30, 45, 0.9) 100%) !important;
+  border-color: var(--cyber-magenta) !important;
+}
+
+.drop-target {
+  border-style: dashed;
+}
+
+/* === REM POSITION FIX === */
+.rem-position-fix {
+  position: static !important;
+}
+
+/* === BOUNDED CONTAINER === */
+.bounded-container {
+  height: 500px;
+  width: 500px;
+  position: relative;
+  overflow: auto;
+  padding: 0;
+  background: var(--cyber-surface);
+  border: 1px solid rgba(0, 240, 255, 0.2);
+  background-image:
+    linear-gradient(rgba(0, 240, 255, 0.05) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(0, 240, 255, 0.05) 1px, transparent 1px);
+  background-size: 20px 20px;
+  float: left;
+  margin: 10px;
+}
+
+.bounded-inner {
+  height: 1000px;
+  width: 1000px;
+  padding: 10px;
+}
+
+/* === ACTIVE DRAGS COUNTER === */
+.active-drags {
+  font-family: 'Orbitron', sans-serif;
+  color: var(--cyber-yellow);
+  background: rgba(250, 204, 21, 0.1);
+  border: 1px solid rgba(250, 204, 21, 0.3);
+  padding: 8px 15px;
+  display: inline-block;
+  margin-bottom: 20px;
+  font-size: 12px;
+}
+
+/* === SCROLLBAR === */
+::-webkit-scrollbar {
+  width: 8px;
+  height: 8px;
+}
+
+::-webkit-scrollbar-track {
+  background: var(--cyber-bg);
+}
+
+::-webkit-scrollbar-thumb {
+  background: linear-gradient(180deg, var(--cyber-cyan), var(--cyber-magenta));
+  border-radius: 4px;
+}
+
+::-webkit-scrollbar-thumb:hover {
+  background: linear-gradient(180deg, var(--cyber-magenta), var(--cyber-cyan));
+}
+
+/* === PREVENT TEXT SELECTION DURING DRAG === */
+body:has(.react-draggable-dragging) {
+  user-select: none;
+  -webkit-user-select: none;
+}
+
+/* === RESPONSIVE === */
+@media (max-width: 768px) {
+  .main-content {
+    padding: 15px;
+  }
+
+  .main-header {
+    flex-direction: column;
+    gap: 10px;
+    align-items: flex-start;
+  }
+
+  h1 {
+    font-size: 18px;
+  }
+
+  .box {
+    width: 150px;
+    height: 150px;
+  }
+}

--- a/example/example.js
+++ b/example/example.js
@@ -75,11 +75,12 @@ class App extends React.Component {
     const {deltaPosition, controlledPosition} = this.state;
     return (
       <div>
-        <h1>React Draggable</h1>
-        <p>Active DragHandlers: {this.state.activeDrags}</p>
-        <p>
-          <a href="https://github.com/STRML/react-draggable/blob/master/example/example.js">Demo Source</a>
-        </p>
+        <div className="active-drags">Active DragHandlers: {this.state.activeDrags}</div>
+        <ul className="nav-links">
+          <li><a href="https://github.com/react-grid-layout/react-draggable/blob/master/example/example.js">Demo Source</a></li>
+          <li><a href="https://github.com/react-grid-layout/react-draggable">GitHub</a></li>
+          <li><a href="https://www.npmjs.com/package/react-draggable">npm</a></li>
+        </ul>
         <Draggable {...dragHandlers}>
           <div className="box">I can be dragged anywhere</div>
         </Draggable>
@@ -107,8 +108,8 @@ class App extends React.Component {
         <Draggable handle="strong">
           <div className="box no-cursor" style={{display: 'flex', flexDirection: 'column'}}>
             <strong className="cursor"><div>Drag here</div></strong>
-            <div style={{overflow: 'scroll'}}>
-              <div style={{background: 'yellow', whiteSpace: 'pre-wrap'}}>
+            <div style={{overflow: 'scroll', flex: 1}}>
+              <div style={{background: 'rgba(250, 204, 21, 0.2)', border: '1px solid rgba(250, 204, 21, 0.4)', padding: '8px', whiteSpace: 'pre-wrap', color: 'var(--cyber-yellow)'}}>
                 I have long scrollable content with a handle
                 {'\n' + Array(40).fill('x').join('\n')}
               </div>
@@ -136,8 +137,8 @@ class App extends React.Component {
         <Draggable {...dragHandlers} onStop={this.onDrop}>
           <div className={`box ${this.state.activeDrags ? "no-pointer-events" : ""}`}>I can be dropped onto another box.</div>
         </Draggable>
-        <div className="box" style={{height: '500px', width: '500px', position: 'relative', overflow: 'auto', padding: '0'}}>
-          <div style={{height: '1000px', width: '1000px', padding: '10px'}}>
+        <div className="bounded-container">
+          <div className="bounded-inner">
             <Draggable bounds="parent" {...dragHandlers}>
               <div className="box">
                 I can only be moved within my offsetParent.<br /><br />

--- a/example/index.html
+++ b/example/index.html
@@ -2,80 +2,27 @@
 <html>
 <head>
   <meta charset="utf-8"/>
+  <meta name="viewport" content="width=device-width, initial-scale=1"/>
   <title>React Draggable</title>
-  <style type="text/css">
-    * {
-      box-sizing: border-box;
-    }
-    html, body {
-      height: 100%;
-    }
-
-    body {
-      color: #222;
-      font-family: "Helvetica Neue", sans-serif;
-      font-weight: 200;
-      margin: 0 50px;
-    }
-
-    .react-draggable, .cursor {
-      cursor: move;
-    }
-    .no-cursor {
-      cursor: auto;
-    }
-    .cursor-y {
-      cursor: ns-resize;
-    }
-    .cursor-x {
-      cursor: ew-resize;
-    }
-
-    .react-draggable strong {
-      background: #ddd;
-      border: 1px solid #999;
-      border-radius: 3px;
-      display: block;
-      margin-bottom: 10px;
-      padding: 3px 5px;
-      text-align: center;
-    }
-
-    .box {
-      background: #fff;
-      border: 1px solid #999;
-      border-radius: 3px;
-      width: 180px;
-      height: 180px;
-      margin: 10px;
-      padding: 10px;
-      float: left;
-    }
-    .no-pointer-events {
-      pointer-events: none;
-    }
-    .hovered {
-      background-color: gray;
-    }
-
-
-    /*
-     * RemWrapper needs to take it's styles from this element,
-     * and this element can't have an absolute position after it's kicked in.
-     * AFAIK it's not possible to do this directly in the RemWrapper component.
-     */
-    .rem-position-fix {
-      position: static !important;
-    }
-  </style>
+  <link rel="stylesheet" href="example-styles.css"/>
 </head>
 <body>
-<div id="container"></div>
-<script src="//unpkg.com/react@16/umd/react.development.js"></script>
-<script src="//unpkg.com/react-dom@16/umd/react-dom.development.js"></script>
+<div class="main-content">
+  <header class="main-header">
+    <h1>React-Draggable</h1>
+    <div class="header-links">
+      <a class="lib-link" href="https://react-grid-layout.github.io/react-grid-layout/examples/0-showcase.html">React-Grid-Layout</a>
+      <a class="lib-link" href="https://react-grid-layout.github.io/react-resizable/examples/example.html">React-Resizable</a>
+      <a class="version-badge" href="https://github.com/react-grid-layout/react-draggable">v4.5.0</a>
+    </div>
+  </header>
+  <div id="container"></div>
+</div>
+<script src="//unpkg.com/react@18/umd/react.development.js"></script>
+<script src="//unpkg.com/react-dom@18/umd/react-dom.development.js"></script>
 <script src="../build/web/react-draggable.min.js"></script>
 <!-- for imported script -->
 <script src="//unpkg.com/@babel/standalone/babel.min.js"></script>
-<script type="text/babel" src="../example/example.js"></script>
+<script type="text/babel" src="example.js"></script>
 </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "test:all": "yarn test && yarn test:browser",
     "dev": "make dev",
     "build": "make clean build",
+    "build-example": "mkdir -p example/build/web && cp build/web/react-draggable.min.js example/build/web/ && sed -i.bak 's|../build/web/react-draggable|build/web/react-draggable|g' example/index.html && rm -f example/index.html.bak",
     "lint": "make lint",
     "flow": "flow"
   },


### PR DESCRIPTION
## Summary

- Add gh-pages workflow that deploys examples on tag push
- Create cyberpunk CSS theme matching react-resizable and react-grid-layout
- Update example page with header links to companion libraries
- Add `build-example` script to prepare bundle for gh-pages
- Reformat README for improved readability with props table

## Test plan

- [x] `yarn dev` works locally
- [x] `yarn build && yarn build-example` succeeds
- [x] All tests pass
- [ ] Deploy by pushing a tag to trigger the workflow